### PR TITLE
4 New Effects, 4 Updated Effects

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="Effects\db\Peds\PedsRagdollOnTouch.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsReviveNearby.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsRiot.cpp" />
+    <ClCompile Include="Effects\db\Peds\PedsSpawnAngryClown.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsSpawnAngryJesus.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsSpawnAngryJesus2.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsSpawnCompanionBrad.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="Effects\db\Vehs\VehsJumpy.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsLockAll.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsPlayerVehRandomSeat.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsPopTire.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsTriggerAlarm.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsNoGrav.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsNoTraffic.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="Effects\db\Vehs\VehsJesusTakeTheWheel.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsJumpy.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsLockAll.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsOneHitKO.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsPlayerVehRandomSeat.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsPopTire.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsTriggerAlarm.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="Effects\db\Misc\MiscSpawnUFO.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscTimecycModifierController.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscTotalChaos.cpp" />
+    <ClCompile Include="Effects\db\Misc\MiscWaves.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscWhaleRain.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsAimbot.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsBlind.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -417,6 +417,12 @@
     <ClCompile Include="Effects\db\Vehs\VehsOneHitKO.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Effects\db\Misc\MiscScaleformHacking.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Effects\db\Misc\MiscWaves.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\vendor\scripthookv\lib\ScriptHookV.lib" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -414,6 +414,9 @@
     <ClCompile Include="Effects\db\Peds\PedsSpawnAngryClown.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Effects\db\Vehs\VehsOneHitKO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\vendor\scripthookv\lib\ScriptHookV.lib" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClCompile Include="Effects\db\Vehs\VehsJesusTakeTheWheel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Effects\db\Vehs\VehsPopTire.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\vendor\scripthookv\lib\ScriptHookV.lib" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -411,6 +411,9 @@
     <ClCompile Include="Effects\db\Vehs\VehsPopTire.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Effects\db\Peds\PedsSpawnAngryClown.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\vendor\scripthookv\lib\ScriptHookV.lib" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -192,6 +192,7 @@ enum EffectType
 	EFFECT_JESUS_TAKE_THE_WHEEL,
 	EFFECT_VEH_POP_TIRE_LOOP,
 	EFFECT_ANGRY_CLOWN,
+	EFFECT_OHKO_VEHICLES,
 	_EFFECT_ENUM_MAX
 };
 
@@ -397,5 +398,6 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_PEDS_RAGDOLL, {"All Peds Ragdoll", "peds_ragdoll"}},
 	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}},
 	{EFFECT_VEH_POP_TIRE_LOOP, {"Random Tire Popping", "veh_poptire", true, {}, true}},
-	{EFFECT_ANGRY_CLOWN, {"Spawn Angry Clown", "peds_angryclown"}}
+	{EFFECT_ANGRY_CLOWN, {"Spawn Angry Clown", "peds_angryclown"}},
+	{EFFECT_OHKO_VEHICLES, {"One Hit KO Vehicles", "vehs_ohko", true}}
 };

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -191,6 +191,7 @@ enum EffectType
 	EFFECT_VEH_SET_TOPSPEED_30MPH,
 	EFFECT_JESUS_TAKE_THE_WHEEL,
 	EFFECT_VEH_POP_TIRE_LOOP,
+	EFFECT_ANGRY_CLOWN,
 	_EFFECT_ENUM_MAX
 };
 
@@ -395,5 +396,6 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_VEH_SET_TOPSPEED_30MPH, {"30MPH Speed Limit", "veh_30mphlimit", true, {}, true}},
 	{EFFECT_PEDS_RAGDOLL, {"All Peds Ragdoll", "peds_ragdoll"}},
 	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}},
-	{EFFECT_VEH_POP_TIRE_LOOP, {"Random Tire Popping", "veh_poptire", true, {}, true}}
+	{EFFECT_VEH_POP_TIRE_LOOP, {"Random Tire Popping", "veh_poptire", true, {}, true}},
+	{EFFECT_ANGRY_CLOWN, {"Spawn Angry Clown", "peds_angryclown"}}
 };

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -193,6 +193,7 @@ enum EffectType
 	EFFECT_VEH_POP_TIRE_LOOP,
 	EFFECT_ANGRY_CLOWN,
 	EFFECT_OHKO_VEHICLES,
+	EFFECT_MISC_WAVEY,
 	_EFFECT_ENUM_MAX
 };
 
@@ -399,5 +400,6 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}},
 	{EFFECT_VEH_POP_TIRE_LOOP, {"Random Tire Popping", "veh_poptire", true, {}, true}},
 	{EFFECT_ANGRY_CLOWN, {"Spawn Angry Clown", "peds_angryclown"}},
-	{EFFECT_OHKO_VEHICLES, {"One Hit KO Vehicles", "vehs_ohko", true}}
+	{EFFECT_OHKO_VEHICLES, {"One Hit KO Vehicles", "vehs_ohko", true}},
+	{EFFECT_MISC_WAVEY, {"Things Are Getting Wavey", "misc_waves", true}}
 };

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -190,7 +190,7 @@ enum EffectType
 	EFFECT_VEH_SET_RANDOM_SEAT,
 	EFFECT_VEH_SET_TOPSPEED_30MPH,
 	EFFECT_JESUS_TAKE_THE_WHEEL,
-	EFFECT_VEH_POP_TIRE,
+	EFFECT_VEH_POP_TIRE_LOOP,
 	_EFFECT_ENUM_MAX
 };
 
@@ -395,5 +395,5 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_VEH_SET_TOPSPEED_30MPH, {"30MPH Speed Limit", "veh_30mphlimit", true, {}, true}},
 	{EFFECT_PEDS_RAGDOLL, {"All Peds Ragdoll", "peds_ragdoll"}},
 	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}},
-	{EFFECT_VEH_POP_TIRE, {"Pop Random Tires", "veh_poptire"}}
+	{EFFECT_VEH_POP_TIRE_LOOP, {"Random Tire Popping", "veh_poptire", true, {}, true}}
 };

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -190,6 +190,7 @@ enum EffectType
 	EFFECT_VEH_SET_RANDOM_SEAT,
 	EFFECT_VEH_SET_TOPSPEED_30MPH,
 	EFFECT_JESUS_TAKE_THE_WHEEL,
+	EFFECT_VEH_POP_TIRE,
 	_EFFECT_ENUM_MAX
 };
 
@@ -393,5 +394,6 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_VEH_SET_RANDOM_SEAT, {"Teleport Into Random Seat", "veh_randomseat"}},
 	{EFFECT_VEH_SET_TOPSPEED_30MPH, {"30MPH Speed Limit", "veh_30mphlimit", true, {}, true}},
 	{EFFECT_PEDS_RAGDOLL, {"All Peds Ragdoll", "peds_ragdoll"}},
-	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}}
+	{EFFECT_JESUS_TAKE_THE_WHEEL, {"Jesus Take The Wheel", "veh_jesustakethewheel"}},
+	{EFFECT_VEH_POP_TIRE, {"Pop Random Tires", "veh_poptire"}}
 };

--- a/ChaosMod/Effects/db/Misc/MiscBlackout.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscBlackout.cpp
@@ -1,5 +1,10 @@
 #include <stdafx.h>
 
+static void OnStart()
+{
+	SET_CLOCK_TIME(0, 0, 0);
+}
+
 static void OnStop()
 {
 	SET_ARTIFICIAL_LIGHTS_STATE(false);
@@ -10,4 +15,4 @@ static void OnTick()
 	SET_ARTIFICIAL_LIGHTS_STATE(true);
 }
 
-static RegisterEffect registerEffect(EFFECT_BLACKOUT, nullptr, OnStop, OnTick);
+static RegisterEffect registerEffect(EFFECT_BLACKOUT, OnStart, OnStop, OnTick);

--- a/ChaosMod/Effects/db/Misc/MiscWaves.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscWaves.cpp
@@ -1,0 +1,12 @@
+#include <stdafx.h>
+
+static void OnStart()
+{
+	_0xC54A08C85AE4D410(10);
+}
+static void OnStop()
+{
+	_0xC54A08C85AE4D410(0);
+}
+
+static RegisterEffect registerEffect(EFFECT_MISC_WAVEY, OnStart, OnStop);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryClown.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryClown.cpp
@@ -20,7 +20,7 @@ static void OnStart()
 	SET_PED_COMBAT_ATTRIBUTES(ped, 46, true);
 	SET_PED_COMBAT_ATTRIBUTES(ped, 0, true);
 	
-	GIVE_WEAPON_TO_PED(ped, GET_HASH_KEY("WEAPON_RAYPISTOL"), 9999, true, true); // give the clown a up n atomizer
+	GIVE_WEAPON_TO_PED(ped, GET_HASH_KEY("WEAPON_RAYPISTOL"), 9999, true, true); // give the clown an up n atomizer
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_MODEL_AS_NO_LONGER_NEEDED(clownHash);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryClown.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryClown.cpp
@@ -1,0 +1,29 @@
+#include <stdafx.h>
+//based on PedsSpawnAngryJesus.cpp
+static void OnStart()
+{
+	static constexpr Hash clownHash = 71929310;
+	LoadModel(clownHash);
+
+	auto playerPed = PLAYER_PED_ID();
+	auto playerPos = GET_ENTITY_COORDS(playerPed, false);
+
+	Ped ped = CREATE_PED(4, clownHash, playerPos.x, playerPos.y, playerPos.z, 0.f, true, false);
+	SET_ENTITY_HEALTH(ped, 500, 0);
+	SET_PED_ARMOUR(ped, 500);
+	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
+	{
+		SET_PED_INTO_VEHICLE(ped, GET_VEHICLE_PED_IS_IN(playerPed, false), -2);
+	}
+
+	SET_PED_COMBAT_ATTRIBUTES(ped, 5, true);
+	SET_PED_COMBAT_ATTRIBUTES(ped, 46, true);
+	SET_PED_COMBAT_ATTRIBUTES(ped, 0, true);
+	
+	GIVE_WEAPON_TO_PED(ped, GET_HASH_KEY("WEAPON_RAYPISTOL"), 9999, true, true); // give the clown a up n atomizer
+	TASK_COMBAT_PED(ped, playerPed, 0, 16);
+
+	SET_MODEL_AS_NO_LONGER_NEEDED(clownHash);
+}
+
+static RegisterEffect registerEffect(EFFECT_ANGRY_CLOWN, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsZombies.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsZombies.cpp
@@ -2,6 +2,8 @@
 
 static void OnStart()
 {
+	SET_PLAYER_WANTED_LEVEL(PLAYER_ID(), 0, false);
+	SET_MAX_WANTED_LEVEL(0);
 	static const auto playerGroupHash = GET_HASH_KEY("PLAYER");
 	static const auto civMaleGroupHash = GET_HASH_KEY("CIVMALE");
 	static const auto civFemaleGroupHash = GET_HASH_KEY("CIVFEMALE");
@@ -15,6 +17,7 @@ static void OnStart()
 
 static void OnStop()
 {
+	SET_MAX_WANTED_LEVEL(5);
 	static const auto zombieGroupHash = GET_HASH_KEY("_ZOMBIES");
 
 	for (Ped ped : GetAllPeds())
@@ -34,7 +37,6 @@ static void OnTick()
 	static Hash zombieGroupHash = GET_HASH_KEY("_ZOMBIES");
 	static Ped zombies[MAX_ZOMBIES] = {};
 	static int zombiesAmount = 0;
-
 	auto playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 	if (zombiesAmount <= MAX_ZOMBIES)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsJesusTakeTheWheel.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsJesusTakeTheWheel.cpp
@@ -13,8 +13,15 @@ static void OnStart()
 		{
 			SET_PED_INTO_VEHICLE(playerPed, veh, -2); // -1 = driver, -2 = First Free Passenger Seat
 			auto jesus = CREATE_PED_INSIDE_VEHICLE(veh, 4, modelHash, -1, true, false);
-			TASK_VEHICLE_DRIVE_WANDER(jesus, veh, 50, 1074528293); // 1074528293 = Rushed, 50 = 50 Meters per second = 111.847 MPH which i think is like the "target" speed.
+			TASK_VEHICLE_DRIVE_WANDER(jesus, veh, 150, 4176732); // 1074528293 = Rushed, 50 = 50 Meters per second = 111.847 MPH which i think is like the "target" speed.
 			SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(jesus, true); // makes ped not panic
+			//1076 == crazy, going in reverse
+			//3688764 pretty crazy, randomly set bits so no idea what this actually is doing tbh lol
+			//943283004 likes being fast
+			//4294967295 all flags in 32 bit, does nothing
+			//4176861 fast again, but not overtaking
+			//4176860 fast, overtaking, stopping at intersections
+			//4176732 
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
@@ -1,0 +1,28 @@
+#include <stdafx.h>
+
+static float VehicleHealth = 0;
+static Vehicle CurrentVehicle = 0;
+
+static void OnTick()
+{
+	auto playerPed = PLAYER_PED_ID();
+
+	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
+	{
+		auto veh = GET_VEHICLE_PED_IS_IN(playerPed, false);
+		if (CurrentVehicle == veh)
+		{
+			if (VehicleHealth != GET_VEHICLE_BODY_HEALTH(veh))
+			{
+				EXPLODE_VEHICLE(veh, true, false);
+			}
+		}
+		else
+		{
+			CurrentVehicle = veh;
+			VehicleHealth = GET_VEHICLE_BODY_HEALTH(veh);
+		}
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_OHKO_VEHICLES, nullptr, nullptr, OnTick);

--- a/ChaosMod/Effects/db/Vehs/VehsPlayerVehRandomSeat.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPlayerVehRandomSeat.cpp
@@ -9,7 +9,7 @@ static void OnStart()
 		auto seats = GET_VEHICLE_MODEL_NUMBER_OF_SEATS(GET_ENTITY_MODEL(veh));
 		if (seats >= 2)
 		{
-			SET_PED_INTO_VEHICLE(playerPed, veh, Random::GetRandomInt(-1, seats - 2));
+			SET_PED_INTO_VEHICLE(playerPed, veh, Random::GetRandomInt(0, seats - 2));
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Vehs/VehsPlayerVehRandomSeat.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPlayerVehRandomSeat.cpp
@@ -9,7 +9,7 @@ static void OnStart()
 		auto seats = GET_VEHICLE_MODEL_NUMBER_OF_SEATS(GET_ENTITY_MODEL(veh));
 		if (seats >= 2)
 		{
-			SET_PED_INTO_VEHICLE(playerPed, veh, Random::GetRandomInt(0, seats - 2));
+			SET_PED_INTO_VEHICLE(playerPed, veh, Random::GetRandomInt(0, seats - 2)); // 0 to seats -2 means passenger seat to any other passenger seat basically, does NOT go into drivers seat (used to be like that)
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Vehs/VehsPopTire.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPopTire.cpp
@@ -1,0 +1,19 @@
+#include <stdafx.h>
+// Not repairing after the effect is intentional. 
+static void OnStart()
+{
+	auto playerPed = PLAYER_PED_ID();
+	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
+	{
+		auto veh = GET_VEHICLE_PED_IS_IN(playerPed, false);
+		for (int i = 0; i < 48; i++) // using code from VehsPopTires.cpp
+		{
+			if (Random::GetRandomInt(0, 1)) // random true / false to get ideally 50% of tires popped.
+			{
+				SET_VEHICLE_TYRE_BURST(veh, i, true, 1000.f);
+			}
+		}
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_VEH_POP_TIRE, OnStart);

--- a/ChaosMod/Effects/db/Vehs/VehsPopTire.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPopTire.cpp
@@ -1,7 +1,8 @@
 #include <stdafx.h>
-// Not repairing after the effect is intentional. 
+// Each tire has a 50% chance of popping or being repaired every 2 seconds.
 static void OnStart()
 {
+	//pop tires once via this since OnTick only fires after the loop time
 	auto playerPed = PLAYER_PED_ID();
 	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
 	{
@@ -12,8 +13,51 @@ static void OnStart()
 			{
 				SET_VEHICLE_TYRE_BURST(veh, i, true, 1000.f);
 			}
+			else
+			{
+				SET_VEHICLE_TYRE_FIXED(veh, i);
+			}
+		}
+	}
+}
+static void OnStop()
+{
+	auto player = PLAYER_PED_ID();
+	if (IS_PED_IN_ANY_VEHICLE(player, false))
+	{
+		auto veh = GET_VEHICLE_PED_IS_IN(player, false);
+		for (int i = 0; i < 48; i++)
+		{
+			SET_VEHICLE_TYRE_FIXED(veh, i);
+		}
+	}
+}
+static void OnTick()
+{
+	static DWORD64 lastTick = GetTickCount64();
+	DWORD64 currentTick = GetTickCount64();
+
+	if (lastTick < currentTick - 2000) // 2000MS = every 2 seconds.
+	{
+		lastTick = currentTick;
+
+		auto playerPed = PLAYER_PED_ID();
+		if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
+		{
+			auto veh = GET_VEHICLE_PED_IS_IN(playerPed, false);
+			for (int i = 0; i < 48; i++) // using code from VehsPopTires.cpp
+			{
+				if (Random::GetRandomInt(0, 1)) // random true / false to get ideally 50% of tires popped.
+				{
+					SET_VEHICLE_TYRE_BURST(veh, i, true, 1000.f);
+				}
+				else
+				{
+					SET_VEHICLE_TYRE_FIXED(veh, i);
+				}
+			}
 		}
 	}
 }
 
-static RegisterEffect registerEffect(EFFECT_VEH_POP_TIRE, OnStart);
+static RegisterEffect registerEffect(EFFECT_VEH_POP_TIRE_LOOP, OnStart, OnStop, OnTick);

--- a/ChaosMod/Effects/db/Vehs/VehsSpawner.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpawner.cpp
@@ -90,8 +90,7 @@ static void OnStartRandom()
 
 	if (!vehModels.empty())
 	{
-		auto vehHash = vehModels[Random::GetRandomInt(0, vehModels.size() - 1)];
-		CreateTempVehicleOnPlayerPos(vehHash, GET_ENTITY_HEADING(PLAYER_PED_ID()));
+		CreateTempVehicleOnPlayerPos(vehModels[Random::GetRandomInt(0, vehModels.size() - 1)], GET_ENTITY_HEADING(PLAYER_PED_ID()));
 	}
 }
 

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -226,6 +226,7 @@ namespace ConfigApp
             EFFECT_JESUS_TAKE_THE_WHEEL,
             EFFECT_VEH_POP_TIRE_LOOP,
             EFFECT_ANGRY_CLOWN,
+            EFFECT_OHKO_VEHICLES,
             _EFFECT_ENUM_MAX
         }
 
@@ -416,7 +417,8 @@ namespace ConfigApp
             {EffectType.EFFECT_VEH_SET_TOPSPEED_30MPH, new EffectInfo("30MPH Speed Limit", EffectCategory.VEHICLE, "veh_30mphlimit", true, true) },
             {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel")},
             {EffectType.EFFECT_VEH_POP_TIRE_LOOP, new EffectInfo("Random Tire Popping", EffectCategory.VEHICLE, "veh_poptire", true, true)},
-            {EffectType.EFFECT_ANGRY_CLOWN, new EffectInfo("Spawn Angry Clown", EffectCategory.PEDS, "peds_angryclown")}
+            {EffectType.EFFECT_ANGRY_CLOWN, new EffectInfo("Spawn Angry Clown", EffectCategory.PEDS, "peds_angryclown")},
+            {EffectType.EFFECT_OHKO_VEHICLES, new EffectInfo("One Hit KO Vehicles", EffectCategory.VEHICLE, "vehs_ohko", true)}
         };
     }
 }

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -225,6 +225,7 @@ namespace ConfigApp
             EFFECT_PEDS_RAGDOLL,
             EFFECT_JESUS_TAKE_THE_WHEEL,
             EFFECT_VEH_POP_TIRE_LOOP,
+            EFFECT_ANGRY_CLOWN,
             _EFFECT_ENUM_MAX
         }
 
@@ -414,7 +415,8 @@ namespace ConfigApp
             {EffectType.EFFECT_VEH_SET_RANDOM_SEAT, new EffectInfo("Teleport Into Random Seat", EffectCategory.VEHICLE, "veh_randomseat")},
             {EffectType.EFFECT_VEH_SET_TOPSPEED_30MPH, new EffectInfo("30MPH Speed Limit", EffectCategory.VEHICLE, "veh_30mphlimit", true, true) },
             {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel")},
-            {EffectType.EFFECT_VEH_POP_TIRE_LOOP, new EffectInfo("Random Tire Popping", EffectCategory.VEHICLE, "veh_poptire", true, true)}
+            {EffectType.EFFECT_VEH_POP_TIRE_LOOP, new EffectInfo("Random Tire Popping", EffectCategory.VEHICLE, "veh_poptire", true, true)},
+            {EffectType.EFFECT_ANGRY_CLOWN, new EffectInfo("Spawn Angry Clown", EffectCategory.PEDS, "peds_angryclown")}
         };
     }
 }

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -227,6 +227,7 @@ namespace ConfigApp
             EFFECT_VEH_POP_TIRE_LOOP,
             EFFECT_ANGRY_CLOWN,
             EFFECT_OHKO_VEHICLES,
+            EFFECT_MISC_WAVEY,
             _EFFECT_ENUM_MAX
         }
 
@@ -418,7 +419,8 @@ namespace ConfigApp
             {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel")},
             {EffectType.EFFECT_VEH_POP_TIRE_LOOP, new EffectInfo("Random Tire Popping", EffectCategory.VEHICLE, "veh_poptire", true, true)},
             {EffectType.EFFECT_ANGRY_CLOWN, new EffectInfo("Spawn Angry Clown", EffectCategory.PEDS, "peds_angryclown")},
-            {EffectType.EFFECT_OHKO_VEHICLES, new EffectInfo("One Hit KO Vehicles", EffectCategory.VEHICLE, "vehs_ohko", true)}
+            {EffectType.EFFECT_OHKO_VEHICLES, new EffectInfo("One Hit KO Vehicles", EffectCategory.VEHICLE, "vehs_ohko", true)},
+            {EffectType.EFFECT_MISC_WAVEY, new EffectInfo("Things Are Getting Wavey", EffectCategory.MISC, "misc_waves", true)}
         };
     }
 }

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -224,6 +224,7 @@ namespace ConfigApp
             EFFECT_VEH_SET_TOPSPEED_30MPH,
             EFFECT_PEDS_RAGDOLL,
             EFFECT_JESUS_TAKE_THE_WHEEL,
+            EFFECT_VEH_POP_TIRE,
             _EFFECT_ENUM_MAX
         }
 
@@ -412,7 +413,8 @@ namespace ConfigApp
             {EffectType.EFFECT_VEHS_TRIGGER_ALARM, new EffectInfo("Alarmy Vehicles", EffectCategory.VEHICLE, "vehs_alarmloop", true)},
             {EffectType.EFFECT_VEH_SET_RANDOM_SEAT, new EffectInfo("Teleport Into Random Seat", EffectCategory.VEHICLE, "veh_randomseat")},
             {EffectType.EFFECT_VEH_SET_TOPSPEED_30MPH, new EffectInfo("30MPH Speed Limit", EffectCategory.VEHICLE, "veh_30mphlimit", true, true) },
-            {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel") }
+            {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel")},
+            {EffectType.EFFECT_VEH_POP_TIRE, new EffectInfo("Pop Random Tire(s)", EffectCategory.VEHICLE, "veh_poptire")}
         };
     }
 }

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -224,7 +224,7 @@ namespace ConfigApp
             EFFECT_VEH_SET_TOPSPEED_30MPH,
             EFFECT_PEDS_RAGDOLL,
             EFFECT_JESUS_TAKE_THE_WHEEL,
-            EFFECT_VEH_POP_TIRE,
+            EFFECT_VEH_POP_TIRE_LOOP,
             _EFFECT_ENUM_MAX
         }
 
@@ -414,7 +414,7 @@ namespace ConfigApp
             {EffectType.EFFECT_VEH_SET_RANDOM_SEAT, new EffectInfo("Teleport Into Random Seat", EffectCategory.VEHICLE, "veh_randomseat")},
             {EffectType.EFFECT_VEH_SET_TOPSPEED_30MPH, new EffectInfo("30MPH Speed Limit", EffectCategory.VEHICLE, "veh_30mphlimit", true, true) },
             {EffectType.EFFECT_JESUS_TAKE_THE_WHEEL, new EffectInfo("Jesus Take The Wheel", EffectCategory.VEHICLE, "veh_jesustakethewheel")},
-            {EffectType.EFFECT_VEH_POP_TIRE, new EffectInfo("Pop Random Tire(s)", EffectCategory.VEHICLE, "veh_poptire")}
+            {EffectType.EFFECT_VEH_POP_TIRE_LOOP, new EffectInfo("Random Tire Popping", EffectCategory.VEHICLE, "veh_poptire", true, true)}
         };
     }
 }


### PR DESCRIPTION
New Effects;
- One Hit KO Vehicles: Crashing into anything will cause the vehicle to explode, applies only to vehicle driven by player.
- Spawn Angry Clown: Spawns a clown thats aggro on the player with a up n atomizer and 500 health IIRC
- Things Are Getting Wavey: Waves in ocean get crazy big for timed effect duration (Long)
- Random Tire Popping: Every 2 seconds, each tire has a 50% chance of popping

Updated:
Jesus Take The Wheel:
- Driving style updated to wander more chaotically and target higher speeds

Zombies:
- Cannot be wanted during effects

Teleport into random seat:
- No longer teleports into driver seat, goes into random passenger seat.

Blackout: 
- Sets time to night when activated.