### PR TITLE
Limit "Heavy Recoil" to "Bullet-Weapons"

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerHeavyRecoil.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerHeavyRecoil.cpp
@@ -10,10 +10,14 @@ static void OnTick()
 	Ped player = PLAYER_PED_ID();
 	if (IS_PED_SHOOTING(player)) 
 	{
-		float horizontalRecoil = g_random.GetRandomInt(-30, 30);
-		horizontalRecoil = horizontalRecoil / 10;
-		SET_GAMEPLAY_CAM_RELATIVE_PITCH(GET_GAMEPLAY_CAM_RELATIVE_PITCH() + verticalRecoil, 1.f);
-		SET_GAMEPLAY_CAM_RELATIVE_HEADING(GET_GAMEPLAY_CAM_RELATIVE_HEADING() + horizontalRecoil);
+		Hash weaponHash;
+		if (GET_CURRENT_PED_WEAPON(player, &weaponHash, 1) && GET_WEAPON_DAMAGE_TYPE(weaponHash) == 3)
+		{
+			float horizontalRecoil = g_random.GetRandomInt(-30, 30);
+			horizontalRecoil = horizontalRecoil / 10;
+			SET_GAMEPLAY_CAM_RELATIVE_PITCH(GET_GAMEPLAY_CAM_RELATIVE_PITCH() + verticalRecoil, 1.f);
+			SET_GAMEPLAY_CAM_RELATIVE_HEADING(GET_GAMEPLAY_CAM_RELATIVE_HEADING() + horizontalRecoil);
+		}
 	}
 }
 


### PR DESCRIPTION
Effect applied also to weapons like the jerry can or grenades. Using the Jerry can would result in looking straight up all the time