### PR TITLE
Added a "Lock Vehicle Camera" Effect

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="Effects\db\Player\PlayerLooseTrigger.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerWantedController.cpp" />
     <ClCompile Include="Effects\db\Time\TimeSuperhot.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsLockCamera.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsWeapons.cpp" />
     <ClCompile Include="Effects\db\Weather\WeatherSnow.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscSpawnController.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -179,6 +179,7 @@
     <ClCompile Include="Effects\db\Peds\PedsExplosiveCombat.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsMercenaries.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerFakeDeath.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsLockCamera.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DebugMenu.h" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -214,6 +214,7 @@ enum EffectType
 	EFFECT_LOOSE_TRIGGER,
 	EFFECT_MISC_FLAMETHROWER,
 	EFFECT_PLAYER_FAKEDEATH,
+	EFFECT_VEH_LOCKCAMERA,
 	_EFFECT_ENUM_MAX
 };
 
@@ -442,4 +443,5 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_MISC_FLAMETHROWER, {"Flamethrowers", "misc_flamethrower", true}},
 	{EFFECT_PLAYER_FAKEDEATH, {"Fake Death", "player_fakedeath"}},
 	{EFFECT_GAMESPEED_SUPERHOT, {"Superhot", "time_superhot", true}},
+	{EFFECT_VEH_LOCKCAMERA,  {"Lock Vehicle Camera", "veh_lockcamera", true}},
 };

--- a/ChaosMod/Effects/db/Vehs/VehsLockCamera.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsLockCamera.cpp
@@ -1,0 +1,13 @@
+/*
+	Effect by dzwdz
+*/
+
+#include <stdafx.h>
+
+static void OnTick()
+{
+	if (IS_PED_IN_ANY_VEHICLE(PLAYER_PED_ID(), false))
+		_SET_GAMEPLAY_CAM_RELATIVE_ROTATION((float)0.0, (float)0.0, (float)0.0);
+}
+
+static RegisterEffect registerEffect(EFFECT_VEH_LOCKCAMERA, nullptr, nullptr, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -248,6 +248,7 @@ namespace ConfigApp
             EFFECT_MISC_FLAMETHROWER,
             EFFECT_PLAYER_FAKEDEATH,
             EFFECT_GAMESPEED_SUPERHOT,
+            EFFECT_VEH_LOCKCAMERA,
             _EFFECT_ENUM_MAX
         }
 
@@ -461,6 +462,7 @@ namespace ConfigApp
             {EffectType.EFFECT_MISC_FLAMETHROWER, new EffectInfo("Flamethrowers", EffectCategory.MISC, "misc_flamethrower", true)},
             {EffectType.EFFECT_PLAYER_FAKEDEATH, new EffectInfo("Fake Death", EffectCategory.PLAYER, "player_fakedeath")},
             {EffectType.EFFECT_GAMESPEED_SUPERHOT, new EffectInfo("Superhot", EffectCategory.TIME, "time_superhot", true)},
+            {EffectType.EFFECT_VEH_LOCKCAMERA,  new EffectInfo("Lock Vehicle Camera", EffectCategory.VEHICLE, "veh_lockcamera", true)},
         };
     }
 }


### PR DESCRIPTION
Locks the camera's yaw to be always straight behind player's vehicle, similarly to how it had worked in GTASA.