### PR TITLE
Fixed Loose Trigger

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsLooseTrigger.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsLooseTrigger.cpp
@@ -41,4 +41,4 @@ static void OnTick()
 	}
 }
 
-static RegisterEffect registerEffect(EFFECT_LOOSE_TRIGGER, nullptr, nullptr, OnTick);
+static RegisterEffect registerEffect(EFFECT_LOOSE_TRIGGER, nullptr, OnStop, OnTick);


### PR DESCRIPTION
After the effect ended, infinite ammo stayed