### PR TITLE
Implement Turn Turtle (player_flip_camera)

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="Effects\db\Misc\MiscRainbowWeps.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscRollCredits.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsIntoRandomVehs.cpp" />
+    <ClCompile Include="Effects\db\Player\PlayerFlipCamera.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerForcefield.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerHeavyRecoil.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerKeepRunning.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -185,6 +185,7 @@
     <ClCompile Include="Effects\db\Player\PlayerSimeonSays.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsLooseTrigger.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsLockCamera.cpp" />
+    <ClCompile Include="Effects\db\Player\PlayerFlipCamera.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DebugMenu.h" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -220,6 +220,7 @@ enum EffectType
 	EFFECT_PLAYER_POOF,
 	EFFECT_PLAYER_SIMEONSAYS,
 	EFFECT_VEH_LOCKCAMERA,
+	EFFECT_FLIP_CAMERA,
 	_EFFECT_ENUM_MAX
 };
 
@@ -454,4 +455,5 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_PLAYER_POOF, {"Deadly Aim", "player_poof", true}},
 	{EFFECT_PLAYER_SIMEONSAYS, {"Simeon Says", "player_simeonsays", true, {}, true}},
 	{EFFECT_VEH_LOCKCAMERA,  {"Lock Vehicle Camera", "veh_lockcamera", true}},
+	{EFFECT_FLIP_CAMERA, {"Turn Turtle", "player_flip_camera", true}}
 };

--- a/ChaosMod/Effects/db/Player/PlayerFlipCamera.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFlipCamera.cpp
@@ -1,0 +1,41 @@
+/*
+	Effect by DrUnderscore (James)
+*/
+
+#include <stdafx.h>
+// TODO: SHVDN has a memory pattern for the gameplay camera, so it might be wise at some point
+// to use it to directly modify the rotation of the camera, but that's for a later date :^)
+
+static Camera flippedCamera = 0;
+
+static void UpdateCamera()
+{
+    auto coord = CAM::GET_GAMEPLAY_CAM_COORD();
+    auto rot = CAM::GET_GAMEPLAY_CAM_ROT(2);
+    auto fov = CAM::GET_GAMEPLAY_CAM_FOV();
+    CAM::SET_CAM_PARAMS(flippedCamera, coord.x, coord.y, coord.z, rot.x, 180.0f, rot.z, fov, 0, 1, 1, 2);
+}
+
+static void OnStart()
+{
+    flippedCamera = CAM::CREATE_CAM("DEFAULT_SCRIPTED_CAMERA", 1);
+    CAM::SET_CAM_ACTIVE(flippedCamera, true);
+    UpdateCamera();
+    CAM::RENDER_SCRIPT_CAMS(true, 0, 3000, 1, 0, 0);
+}
+
+static void OnTick()
+{
+    UpdateCamera();
+}
+
+static void OnEnd()
+{
+    CAM::SET_CAM_ACTIVE(flippedCamera, false);
+    CAM::RENDER_SCRIPT_CAMS(false, 0, 3000, 1, 0, 0);
+    CAM::DESTROY_CAM(flippedCamera, false);
+
+    flippedCamera = 0;
+}
+
+static RegisterEffect registerEffect(EFFECT_FLIP_CAMERA, OnStart, OnEnd, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -254,6 +254,7 @@ namespace ConfigApp
             EFFECT_PLAYER_POOF,
             EFFECT_PLAYER_SIMEONSAYS,
             EFFECT_VEH_LOCKCAMERA,
+            EFFECT_FLIP_CAMERA,
             _EFFECT_ENUM_MAX
         }
 
@@ -473,6 +474,7 @@ namespace ConfigApp
             {EffectType.EFFECT_PLAYER_POOF, new EffectInfo("Deadly Aim", EffectCategory.PLAYER, "player_poof", true)},
             {EffectType.EFFECT_PLAYER_SIMEONSAYS, new EffectInfo("Simeon Says", EffectCategory.PLAYER, "player_simeonsays", true, true)},
             {EffectType.EFFECT_VEH_LOCKCAMERA,  new EffectInfo("Lock Vehicle Camera", EffectCategory.VEHICLE, "veh_lockcamera", true)},
+            {EffectType.EFFECT_FLIP_CAMERA, new EffectInfo("Turn Turtle", EffectCategory.PLAYER, "player_flip_camera", true)},
         };
     }
 }


### PR DESCRIPTION
This will create a new rendering camera, make it active, and render it.
Each tick it will follow the gameplay camera, except have it's roll set
to 180 degrees.

Currently, the biggest issue is that the camera will not go back to
normal once the effect ends. In my own mod, it works perfectly, but
inside of chaos something is different that I've yet to figure out. Any
input on this would be much appreciated.

Resolves #81