### PR TITLE
Implement Peds Drive Backwards

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="Effects\db\Misc\MiscBlackout.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscEarthquake.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscSuperStunt.cpp" />
+    <ClCompile Include="Effects\db\Peds\PedsDriveBackwards.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsKillerClowns.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsJamesBond.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsLooseTrigger.cpp" />

--- a/ChaosMod/ChaosMod.vcxproj.filters
+++ b/ChaosMod/ChaosMod.vcxproj.filters
@@ -188,6 +188,7 @@
     <ClCompile Include="Effects\db\Player\PlayerFlipCamera.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerKickflip.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerOnDemandCartoon.cpp" />
+    <ClCompile Include="Effects\db\Peds\PedsDriveBackwards.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DebugMenu.h" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -225,6 +225,7 @@ enum EffectType
 	EFFECT_SCREEN_NEED_GLASSES,
 	EFFECT_FLIP_CAMERA,
 	EFFECT_PLAYER_ON_DEMAND_CARTOON,
+	EFFECT_PEDS_DRIVE_BACKWARDS,
 	_EFFECT_ENUM_MAX
 };
 
@@ -464,4 +465,5 @@ const std::map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_MISC_SUPER_STUNT, {"Super Stunt", "misc_superstunt"}},
 	{EFFECT_FLIP_CAMERA, {"Turn Turtle", "player_flip_camera", true}},
 	{EFFECT_PLAYER_ON_DEMAND_CARTOON, {"On-Demand TV", "player_on_demand_cartoon", true}},
+	{EFFECT_PEDS_DRIVE_BACKWARDS, {"Peds Drive Backwards", "peds_drive_backwards", true}},
 };

--- a/ChaosMod/Effects/db/Peds/PedsDriveBackwards.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsDriveBackwards.cpp
@@ -1,0 +1,16 @@
+#include <stdafx.h>
+
+static void OnTick()
+{
+	static unsigned int constexpr DRIVING_STYLE = 1024; // "Drive in reverse gear" bit
+
+	for (auto ped : GetAllPeds())
+	{
+		if(ped == PLAYER::PLAYER_PED_ID() || !PED::IS_PED_IN_ANY_VEHICLE(ped, false))
+			continue;
+
+		TASK::SET_DRIVE_TASK_DRIVING_STYLE(ped, 1024);
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_PEDS_DRIVE_BACKWARDS, nullptr, nullptr, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -260,6 +260,7 @@ namespace ConfigApp
             EFFECT_SCREEN_NEED_GLASSES,
             EFFECT_FLIP_CAMERA,
             EFFECT_PLAYER_ON_DEMAND_CARTOON,
+            EFFECT_PEDS_DRIVE_BACKWARDS,
             _EFFECT_ENUM_MAX
         }
 
@@ -485,6 +486,7 @@ namespace ConfigApp
             {EffectType.EFFECT_SCREEN_NEED_GLASSES,  new EffectInfo("I Need Glasses", EffectCategory.MISC, "screen_needglasses", true)},
             {EffectType.EFFECT_FLIP_CAMERA, new EffectInfo("Turn Turtle", EffectCategory.PLAYER, "player_flip_camera", true)},
             {EffectType.EFFECT_PLAYER_ON_DEMAND_CARTOON, new EffectInfo("On-Demand TV", EffectCategory.PLAYER, "player_on_demand_cartoon", true)},
+            {EffectType.EFFECT_PEDS_DRIVE_BACKWARDS, new EffectInfo("Peds Drive Backwards", EffectCategory.PEDS, "peds_drive_backwards", true)},
         };
     }
 }


### PR DESCRIPTION
When activated, all peds in vehicles will have their task driving style set to 1024,
which will make them perform their vehicle task in reverse gear.