### PR TITLE
Correct namespace usage

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
@@ -6,7 +6,7 @@
 
 static void OnStop()
 {
-	CAM:STOP_GAMEPLAY_CAM_SHAKING(true);
+	CAM::STOP_GAMEPLAY_CAM_SHAKING(true);
 }
 
 static void OnTick()


### PR DESCRIPTION
The only reason this worked is because the compiler interpreted `CAM:` as a label, and `nativesNoNamespaces.h` allowed the native to be called without a namespace.