### PR TITLE
Use MISC::GET_GAME_TIMER in place of GetTickCount64

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscLag.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscLag.cpp
@@ -15,7 +15,7 @@ static void OnTickLag()
 {
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (curTick > lastTick + 500)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscLag.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscLag.cpp
@@ -15,7 +15,7 @@ static void OnTickLag()
 {
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (curTick > lastTick + 500)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
@@ -13,7 +13,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (meteorsAmount <= MAX_METEORS && curTick > lastTick + 200)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
@@ -13,7 +13,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (meteorsAmount <= MAX_METEORS && curTick > lastTick + 200)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscRainbowWeps.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscRainbowWeps.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = GetTickCount64();
-	auto curTick = GetTickCount64();
+	static auto lastTick = MISC::GET_GAME_TIMER();
+	auto curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 100)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscRainbowWeps.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscRainbowWeps.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = MISC::GET_GAME_TIMER();
-	auto curTick = MISC::GET_GAME_TIMER();
+	static auto lastTick = GET_GAME_TIMER();
+	auto curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 100)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscTimecycModifierController.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTimecycModifierController.cpp
@@ -112,7 +112,7 @@ static void OnTickLSD()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();;
+		static DWORD64 timeUntilSteer = GET_GAME_TIMER();;
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -121,11 +121,11 @@ static void OnTickLSD()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = MISC::GET_GAME_TIMER();
+		DWORD64 curTick = GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = MISC::GET_GAME_TIMER();
+			timeUntilSteer = GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Misc/MiscTimecycModifierController.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTimecycModifierController.cpp
@@ -112,7 +112,7 @@ static void OnTickLSD()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = GetTickCount64();
+		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();;
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -121,11 +121,11 @@ static void OnTickLSD()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = GetTickCount64();
+		DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = GetTickCount64();
+			timeUntilSteer = MISC::GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
@@ -4,7 +4,7 @@ static DWORD64 m_anchorTick;
 
 static void OnStart()
 {
-	m_anchorTick = MISC::GET_GAME_TIMER();
+	m_anchorTick = GET_GAME_TIMER();
 
 	SET_WEATHER_TYPE_OVERTIME_PERSIST("THUNDER", 2.f);
 }
@@ -34,9 +34,9 @@ static void OnTick()
 		APPLY_FORCE_TO_ENTITY(prop, 3, 10.f, 5.f, .1f, 0, 0, 0, 0, true, true, true, false, true);
 	}
 
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
 	if (lastTick < curTick - 100)
 	{
 		lastTick = curTick;
@@ -59,7 +59,7 @@ static void OnTick()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();
+		static DWORD64 timeUntilSteer = GET_GAME_TIMER();
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -68,11 +68,11 @@ static void OnTick()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = MISC::GET_GAME_TIMER();
+		DWORD64 curTick = GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = MISC::GET_GAME_TIMER();
+			timeUntilSteer = GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
@@ -59,7 +59,7 @@ static void OnTick()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = GetTickCount64();
+		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -68,11 +68,11 @@ static void OnTick()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = GetTickCount64();
+		DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = GetTickCount64();
+			timeUntilSteer = MISC::GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
@@ -4,7 +4,7 @@ static DWORD64 m_anchorTick;
 
 static void OnStart()
 {
-	m_anchorTick = GetTickCount64();
+	m_anchorTick = MISC::GET_GAME_TIMER();
 
 	SET_WEATHER_TYPE_OVERTIME_PERSIST("THUNDER", 2.f);
 }
@@ -34,9 +34,9 @@ static void OnTick()
 		APPLY_FORCE_TO_ENTITY(prop, 3, 10.f, 5.f, .1f, 0, 0, 0, 0, true, true, true, false, true);
 	}
 
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
-	static DWORD64 lastTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
 	if (lastTick < curTick - 100)
 	{
 		lastTick = curTick;

--- a/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
@@ -7,7 +7,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (curTick > lastTick + 500)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
@@ -7,7 +7,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (curTick > lastTick + 500)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
@@ -12,7 +12,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (whaleAmount <= MAX_WHALES && curTick > lastTick + 200)
 	{

--- a/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
@@ -12,7 +12,7 @@ static void OnTick()
 	Vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
 
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (whaleAmount <= MAX_WHALES && curTick > lastTick + 200)
 	{

--- a/ChaosMod/Effects/db/Peds/PedsFollowPlayer.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsFollowPlayer.cpp
@@ -29,8 +29,8 @@ static void OnTick()
 		m_savedPlayerVeh = playerVeh;
 	}
 
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 2000)
 	{

--- a/ChaosMod/Effects/db/Peds/PedsFollowPlayer.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsFollowPlayer.cpp
@@ -29,8 +29,8 @@ static void OnTick()
 		m_savedPlayerVeh = playerVeh;
 	}
 
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 curTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 2000)
 	{

--- a/ChaosMod/Effects/db/Peds/PedsFrozen.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsFrozen.cpp
@@ -10,8 +10,8 @@ static void OnStop()
 
 static void OnTick()
 {
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 curTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	Ped playerPed = PLAYER_PED_ID();
 	Vector3 playerPos = GET_ENTITY_COORDS(playerPed, false);

--- a/ChaosMod/Effects/db/Peds/PedsFrozen.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsFrozen.cpp
@@ -10,8 +10,8 @@ static void OnStop()
 
 static void OnTick()
 {
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	Ped playerPed = PLAYER_PED_ID();
 	Vector3 playerPos = GET_ENTITY_COORDS(playerPed, false);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
@@ -39,11 +39,11 @@ static void OnStart()
 		SET_PED_INTO_VEHICLE(ped, GET_VEHICLE_PED_IS_IN(playerPed, false), -2);
 	}
 
-	DWORD64 lastTick = GetTickCount64();
+	DWORD64 lastTick = MISC::GET_GAME_TIMER();
 
 	while (!REQUEST_SCRIPT_AUDIO_BANK("DLC_VINEWOOD/DLC_VW_HIDDEN_COLLECTIBLES", true, 0))
 	{
-		DWORD64 curTick = GetTickCount64();
+		DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 		if (lastTick < curTick - 500)
 		{

--- a/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
@@ -39,11 +39,11 @@ static void OnStart()
 		SET_PED_INTO_VEHICLE(ped, GET_VEHICLE_PED_IS_IN(playerPed, false), -2);
 	}
 
-	DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 lastTick = GET_GAME_TIMER();
 
 	while (!REQUEST_SCRIPT_AUDIO_BANK("DLC_VINEWOOD/DLC_VW_HIDDEN_COLLECTIBLES", true, 0))
 	{
-		DWORD64 curTick = MISC::GET_GAME_TIMER();
+		DWORD64 curTick = GET_GAME_TIMER();
 
 		if (lastTick < curTick - 500)
 		{

--- a/ChaosMod/Effects/db/Peds/PedsSpeechController.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpeechController.cpp
@@ -3,7 +3,7 @@
 static void OnTickFriendly()
 {
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{
@@ -27,7 +27,7 @@ static RegisterEffect registerEffect1(EFFECT_PEDS_SAY_HI, nullptr, nullptr, OnTi
 static void OnTickUnfriendly()
 {
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{

--- a/ChaosMod/Effects/db/Peds/PedsSpeechController.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpeechController.cpp
@@ -3,7 +3,7 @@
 static void OnTickFriendly()
 {
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{
@@ -27,7 +27,7 @@ static RegisterEffect registerEffect1(EFFECT_PEDS_SAY_HI, nullptr, nullptr, OnTi
 static void OnTickUnfriendly()
 {
 	static DWORD64 lastTick = 0;
-	DWORD64 curTick = GetTickCount64();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{

--- a/ChaosMod/Effects/db/Player/PlayerAutopilot.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerAutopilot.cpp
@@ -90,8 +90,8 @@ static void OnTick()
 	}
 
 	// Run every 300 ms
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 	if (lastTick > curTick - 300)
 	{
 		return;

--- a/ChaosMod/Effects/db/Player/PlayerAutopilot.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerAutopilot.cpp
@@ -90,8 +90,8 @@ static void OnTick()
 	}
 
 	// Run every 300 ms
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 curTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 	if (lastTick > curTick - 300)
 	{
 		return;

--- a/ChaosMod/Effects/db/Player/PlayerDrunk.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerDrunk.cpp
@@ -45,7 +45,7 @@ static void OnTick()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = GetTickCount64();
+		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -54,11 +54,11 @@ static void OnTick()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = GetTickCount64();
+		DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = GetTickCount64();
+			timeUntilSteer = MISC::GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Player/PlayerDrunk.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerDrunk.cpp
@@ -45,7 +45,7 @@ static void OnTick()
 			return;
 		}
 
-		static DWORD64 timeUntilSteer = MISC::GET_GAME_TIMER();
+		static DWORD64 timeUntilSteer = GET_GAME_TIMER();
 		static bool enableDrunkSteering = false;
 		static float steering;
 
@@ -54,11 +54,11 @@ static void OnTick()
 			SET_VEHICLE_STEER_BIAS(playerVeh, steering);
 		}
 
-		DWORD64 curTick = MISC::GET_GAME_TIMER();
+		DWORD64 curTick = GET_GAME_TIMER();
 
 		if (timeUntilSteer < curTick)
 		{
-			timeUntilSteer = MISC::GET_GAME_TIMER();
+			timeUntilSteer = GET_GAME_TIMER();
 
 			if (enableDrunkSteering)
 			{

--- a/ChaosMod/Effects/db/Player/PlayerSimeonSays.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerSimeonSays.cpp
@@ -64,14 +64,14 @@ static void OnStart()
 	{
 		WAIT(0);
 	}
-	lastTime = MISC::GET_GAME_TIMER();
+    lastTime = GetTickCount64();
 	waitTime = 2000;
 	SET_TIME_SCALE(0.1f);
 	BEGIN_SCALEFORM_MOVIE_METHOD(scaleForm, "SHOW_SHARD_RANKUP_MP_MESSAGE");
 	SCALEFORM_MOVIE_METHOD_ADD_PARAM_PLAYER_NAME_STRING(message.c_str());
 	END_SCALEFORM_MOVIE_METHOD();
 
-	while (MISC::GET_GAME_TIMER() - lastTime < waitTime)
+    while (GetTickCount64() - lastTime < waitTime)
 	{
 		WAIT(0);
 		DRAW_SCALEFORM_MOVIE_FULLSCREEN(scaleForm, 255, 255, 255, 255, 0);

--- a/ChaosMod/Effects/db/Player/PlayerSimeonSays.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerSimeonSays.cpp
@@ -64,14 +64,14 @@ static void OnStart()
 	{
 		WAIT(0);
 	}
-	lastTime = GetTickCount64();
+	lastTime = MISC::GET_GAME_TIMER();
 	waitTime = 2000;
 	SET_TIME_SCALE(0.1f);
 	BEGIN_SCALEFORM_MOVIE_METHOD(scaleForm, "SHOW_SHARD_RANKUP_MP_MESSAGE");
 	SCALEFORM_MOVIE_METHOD_ADD_PARAM_PLAYER_NAME_STRING(message.c_str());
 	END_SCALEFORM_MOVIE_METHOD();
 
-	while (GetTickCount64() - lastTime < waitTime)
+	while (MISC::GET_GAME_TIMER() - lastTime < waitTime)
 	{
 		WAIT(0);
 		DRAW_SCALEFORM_MOVIE_FULLSCREEN(scaleForm, 255, 255, 255, 255, 0);

--- a/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = GetTickCount64();
-	auto curTick = GetTickCount64();
+	static auto lastTick = MISC::GET_GAME_TIMER();
+	auto curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 100)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = MISC::GET_GAME_TIMER();
-	auto curTick = MISC::GET_GAME_TIMER();
+	static auto lastTick = GET_GAME_TIMER();
+	auto curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 100)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
@@ -14,8 +14,8 @@ static void OnStop()
 
 static void OnTick()
 {
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsOneHitKO.cpp
@@ -14,8 +14,8 @@ static void OnStop()
 
 static void OnTick()
 {
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 curTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 1000)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsPopTiresRandom.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPopTiresRandom.cpp
@@ -6,8 +6,8 @@
 
 static void OnTick()
 {
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 currentTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 currentTick = GET_GAME_TIMER();
 
 	if (lastTick < currentTick - 1750) // 1750MS = every 1.75 seconds.
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsPopTiresRandom.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsPopTiresRandom.cpp
@@ -6,8 +6,8 @@
 
 static void OnTick()
 {
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 currentTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 currentTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < currentTick - 1750) // 1750MS = every 1.75 seconds.
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
@@ -6,8 +6,8 @@
 
 static void OnTick()
 {
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 currentTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 currentTick = GET_GAME_TIMER();
 
 	if (lastTick < currentTick - 500) //every second, half of second
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
@@ -6,8 +6,8 @@
 
 static void OnTick()
 {
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 currentTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 currentTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < currentTick - 500) //every second, half of second
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
@@ -42,7 +42,7 @@ static void OnTick()
 
 			m_lastVeh = 0;
 			m_timeReserve = WAIT_TIME;
-			m_lastTick = MISC::GET_GAME_TIMER();
+			m_lastTick = GET_GAME_TIMER();
 
 			return;
 		}
@@ -51,7 +51,7 @@ static void OnTick()
 
 		float minSpeed = GET_VEHICLE_MODEL_ESTIMATED_MAX_SPEED(GET_ENTITY_MODEL(veh)) * SPEED_THRESHOLD;
 		float speedms = GET_ENTITY_SPEED(veh);
-		DWORD64 currentTick = MISC::GET_GAME_TIMER();
+		DWORD64 currentTick = GET_GAME_TIMER();
 		DWORD64 tickDelta = currentTick - m_lastTick;
 		int overlaycolor = 0;
 		if (speedms < minSpeed)
@@ -120,7 +120,7 @@ static void OnStart()
 		WAIT(0);
 	}
 	m_enteredVehicle = false;
-	m_lastTick = MISC::GET_GAME_TIMER();
+	m_lastTick = GET_GAME_TIMER();
 	m_lastVeh = 0;
 	m_timeReserve = WAIT_TIME;
 }

--- a/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
@@ -15,7 +15,7 @@ static int m_overlay = 0;
 static Vehicle m_lastVeh;
 
 static DWORD64 m_timeReserve;
-static DWORD64 m_lastTick = GetTickCount64();
+static DWORD64 m_lastTick = 0;
 static bool m_enteredVehicle = false;
 
 static inline bool Beepable(DWORD64 reserveValue)
@@ -42,7 +42,7 @@ static void OnTick()
 
 			m_lastVeh = 0;
 			m_timeReserve = WAIT_TIME;
-			m_lastTick = GetTickCount64();
+			m_lastTick = MISC::GET_GAME_TIMER();
 
 			return;
 		}
@@ -51,7 +51,7 @@ static void OnTick()
 
 		float minSpeed = GET_VEHICLE_MODEL_ESTIMATED_MAX_SPEED(GET_ENTITY_MODEL(veh)) * SPEED_THRESHOLD;
 		float speedms = GET_ENTITY_SPEED(veh);
-		DWORD64 currentTick = GetTickCount64();
+		DWORD64 currentTick = MISC::GET_GAME_TIMER();
 		DWORD64 tickDelta = currentTick - m_lastTick;
 		int overlaycolor = 0;
 		if (speedms < minSpeed)
@@ -120,7 +120,7 @@ static void OnStart()
 		WAIT(0);
 	}
 	m_enteredVehicle = false;
-	m_lastTick = GetTickCount64();
+	m_lastTick = MISC::GET_GAME_TIMER();
 	m_lastVeh = 0;
 	m_timeReserve = WAIT_TIME;
 }

--- a/ChaosMod/Effects/db/Vehs/VehsTriggerAlarm.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsTriggerAlarm.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = GetTickCount64();
-	auto curTick = GetTickCount64();
+	static auto lastTick = MISC::GET_GAME_TIMER();
+	auto curTick = MISC::GET_GAME_TIMER();
 
 	if (lastTick < curTick - 2000)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsTriggerAlarm.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsTriggerAlarm.cpp
@@ -2,8 +2,8 @@
 
 static void OnTick()
 {
-	static auto lastTick = MISC::GET_GAME_TIMER();
-	auto curTick = MISC::GET_GAME_TIMER();
+	static auto lastTick = GET_GAME_TIMER();
+	auto curTick = GET_GAME_TIMER();
 
 	if (lastTick < curTick - 2000)
 	{

--- a/ChaosMod/Effects/db/Vehs/VehsTurnRight.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsTurnRight.cpp
@@ -5,8 +5,8 @@
 Vehicle veh;
 static void OnTick()
 {
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 currentTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 currentTick = MISC::GET_GAME_TIMER();
 
 	//Player vehicle steering locked to the right
 	Ped playerPed = PLAYER_PED_ID();

--- a/ChaosMod/Effects/db/Vehs/VehsTurnRight.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsTurnRight.cpp
@@ -5,8 +5,8 @@
 Vehicle veh;
 static void OnTick()
 {
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 currentTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 currentTick = GET_GAME_TIMER();
 
 	//Player vehicle steering locked to the right
 	Ped playerPed = PLAYER_PED_ID();

--- a/ChaosMod/Effects/db/Weather/WeatherController.cpp
+++ b/ChaosMod/Effects/db/Weather/WeatherController.cpp
@@ -40,8 +40,8 @@ static void OnTickRandom()
 	static constexpr const char* weathers[] = { "CLEAR", "EXTRASUNNY" , "CLOUDS", "OVERCAST", "RAIN", "CLEARING", "THUNDER", "SMOG", "FOGGY", "XMAS", "SNOWLIGHT", "BLIZZARD" };
 	static constexpr int weatherSize = 12;
 
-	static DWORD64 lastTick = GetTickCount64();
-	DWORD64 curTick = GetTickCount64();
+	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
+	DWORD64 curTick = MISC::GET_GAME_TIMER();
 
 	// Note: setting the compare to a low number (e.g. < 1000, or faster than once per sec) could cause the
 	// effect to flicker the screen, which is a known trigger for some types of motion sickness and epilepsy

--- a/ChaosMod/Effects/db/Weather/WeatherController.cpp
+++ b/ChaosMod/Effects/db/Weather/WeatherController.cpp
@@ -40,8 +40,8 @@ static void OnTickRandom()
 	static constexpr const char* weathers[] = { "CLEAR", "EXTRASUNNY" , "CLOUDS", "OVERCAST", "RAIN", "CLEARING", "THUNDER", "SMOG", "FOGGY", "XMAS", "SNOWLIGHT", "BLIZZARD" };
 	static constexpr int weatherSize = 12;
 
-	static DWORD64 lastTick = MISC::GET_GAME_TIMER();
-	DWORD64 curTick = MISC::GET_GAME_TIMER();
+	static DWORD64 lastTick = GET_GAME_TIMER();
+	DWORD64 curTick = GET_GAME_TIMER();
 
 	// Note: setting the compare to a low number (e.g. < 1000, or faster than once per sec) could cause the
 	// effect to flicker the screen, which is a known trigger for some types of motion sickness and epilepsy


### PR DESCRIPTION
GetTickCount64 returns the milliseconds since system startup, which is
real-time. Although this is okay to use, in ~certain~ most cases we would
rather use game time to gain the benefits of it:
- Effected by timescale
- Stops when game is paused
- Isn't real-time :^)

Example of this being beneficial:
The effect Need for Speed is applied. Game is paused. 30 seconds later,
game is unpaused. From the perspective of GetTickCount64, 30 seconds has
passed, and so you instantly fail Need for Speed and explode. With
in-game time, however, it wasn't counting down while paused, so
unpausing will continue the timer as normal.

Another example:
The effect Need for Speed is applied, while a gamespeed effect is also
active. With GetTickCount64, you would have to accelerate to the minimum
speed in real-time 10 seconds (or less), while only having half your
acceleration speed (or less!). With in-game time, however, it's effected
by timescale, so you would be able to accelerate in the slow speed, with
the timer also being slowed.

There are a few places I didn't use this:
- Anything that ISN'T an effect
- Fake death/fake crash, as the timescale change/busy loop would make
  the wait time different than previously.

Some other effects may have been changed in a negative way as well.
Although we should rid all instances of GetTickCount64 (in effects),
let's make sure that the current changes aren't detrimental to the
effect itself.

_extra:_
If GetTickCount64 was called to initialize a static variable in global scope, I omitted it, as it would then cause the native to be executed off the native thread, which is bad!

If it was a static variable initialization _in function scope_, then it was okay, as that is only initialized once reached. _(I think...)_