### PR TITLE
Attempt at fixing bus bois lag/crash

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsBusBois.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsBusBois.cpp
@@ -1,9 +1,12 @@
 #include <stdafx.h>
 
-//effect by ProfessorBiddle, somewhat
+//effect by ProfessorBiddle
 
 static void OnStart()
 {
+	//not sure exactly what to make this, 60 seemed to work ok
+	static const float maxDistance = 60.f;
+
 	static const Hash busHash = GET_HASH_KEY("BUS");
 
 	Ped playerPed = PLAYER_PED_ID();
@@ -12,29 +15,35 @@ static void OnStart()
 	{
 		if (!IS_PED_A_PLAYER(ped) && !IS_PED_DEAD_OR_DYING(ped, false))
 		{
-			if (IS_PED_IN_ANY_VEHICLE(ped, false))
+			Vector3 pedPos = GET_ENTITY_COORDS(ped, true);
+			Vector3 playerPos = GET_ENTITY_COORDS(playerPed, true);
+			//check if player is far away from entity
+			if (GET_DISTANCE_BETWEEN_COORDS(pedPos.x, pedPos.y, pedPos.z, playerPos.x, playerPos.y, playerPos.z, true) <= maxDistance)
 			{
-				Vehicle veh = GET_VEHICLE_PED_IS_IN(ped, false);
-
-				if (GET_ENTITY_MODEL(veh) == busHash)
+				if (IS_PED_IN_ANY_VEHICLE(ped, false))
 				{
-					continue;
+					Vehicle veh = GET_VEHICLE_PED_IS_IN(ped, false);
+
+					if (GET_ENTITY_MODEL(veh) == busHash)
+					{
+						continue;
+					}
 				}
-			}
 
-			Vector3 pedPos = GET_ENTITY_COORDS(ped, false);
-			float pedHeading = GET_ENTITY_HEADING(ped);
+				Vector3 pedPos = GET_ENTITY_COORDS(ped, false);
+				float pedHeading = GET_ENTITY_HEADING(ped);
 
-			SET_ENTITY_COORDS(ped, pedPos.x, pedPos.y, pedPos.z + 10.f, false, false, false, false);
+				SET_ENTITY_COORDS(ped, pedPos.x, pedPos.y, pedPos.z + 10.f, false, false, false, false);
 
-			SET_PED_COMBAT_ATTRIBUTES(ped, 3, false); // Don't allow them to leave vehicle by themselves
+				SET_PED_COMBAT_ATTRIBUTES(ped, 3, false); // Don't allow them to leave vehicle by themselves
 
-			SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(ped, true);
+				SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(ped, true);
 
-			Vehicle veh = CreateTempVehicle(busHash, pedPos.x, pedPos.y, pedPos.z, pedHeading);
-			SET_PED_INTO_VEHICLE(ped, veh, -1);
+				Vehicle veh = CreateTempVehicle(busHash, pedPos.x, pedPos.y, pedPos.z, pedHeading);
+				SET_PED_INTO_VEHICLE(ped, veh, -1);
 
-			TASK_VEHICLE_MISSION_PED_TARGET(ped, veh, playerPed, 13, 9999.f, 4176732, .0f, .0f, false);
+				TASK_VEHICLE_MISSION_PED_TARGET(ped, veh, playerPed, 13, 9999.f, 4176732, .0f, .0f, false);
+			}	
 		}
 	}
 }


### PR DESCRIPTION
Fix: #205

Checks for distance from player now, should reduce the number of entities in buses and hopefully prevent crashes.

Not sure what to set the variable at as I've never had lag/crashing issues, but if someone who is more familiar with GTA coordinate units and how they relate to the actual map has a better suggestion let me know.