### PR TITLE
'Spammy Vehicle Doors' no longer fly off

### DIFF
--- a/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpamDoors.cpp
@@ -16,6 +16,7 @@ static void OnTick()
 			for (int i = 0; i < 7; i++)
 			{
 				SET_VEHICLE_DOOR_OPEN(veh, i, false, false);
+				_SET_VEHICLE_DOOR_CAN_BREAK(veh, i, false);
 			}
 		}
 	}
@@ -30,4 +31,15 @@ static void OnTick()
 	}
 }
 
-static RegisterEffect registerEffect(EFFECT_VEH_SPAM_DOORS, nullptr, nullptr, OnTick);
+static void OnStop()
+{
+	for (auto veh : GetAllVehs())
+	{
+		for (int i = 0; i < 7; i++)
+		{
+			_SET_VEHICLE_DOOR_CAN_BREAK(veh, i, true);
+		}
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_VEH_SPAM_DOORS, nullptr, OnStop, OnTick);


### PR DESCRIPTION
Made it so that doors no longer break during spammy vehicle doors. This is especially for the hood/bonnet which flies off at any significant speed.