### PR TITLE
Adding Blips to Spawned Peds

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsJamesBond.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsJamesBond.cpp
@@ -51,6 +51,10 @@ static void OnStart()
 	GIVE_WEAPON_COMPONENT_TO_PED(bond, GET_HASH_KEY("WEAPON_VINTAGEPISTOL"), GET_HASH_KEY("COMPONENT_AT_PI_SUPP"));
 	SET_PED_ACCURACY(bond, 100);
 	TASK_COMBAT_PED(bond, playerPed, 0, 16);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_JAMES_BOND, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryAlien.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryAlien.cpp
@@ -54,6 +54,10 @@ static void OnStart()
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_ANGRY_ALIEN, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryJesus.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryJesus.cpp
@@ -40,6 +40,10 @@ static void OnStart()
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_ANGRY_JESUS, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryJesus2.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryJesus2.cpp
@@ -55,6 +55,10 @@ static void OnStart()
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_ANGRY_JESUS2, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnAngryJimmy.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnAngryJimmy.cpp
@@ -44,6 +44,10 @@ static void OnStart()
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_ANGRY_JIMMY, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnCompanionBrad.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnCompanionBrad.cpp
@@ -30,6 +30,10 @@ static void OnStart()
 
 	SET_PED_ACCURACY(ped, 100);
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 2);
+	SET_BLIP_AS_FRIENDLY(blip, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_SPAWN_COMPANION_BRAD, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnCompanionChimp.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnCompanionChimp.cpp
@@ -33,6 +33,10 @@ static void OnStart()
 
 	GIVE_WEAPON_TO_PED(ped, GET_HASH_KEY("WEAPON_PISTOL"), 9999, false, true);
 	GIVE_WEAPON_TO_PED(ped, GET_HASH_KEY("WEAPON_CARBINERIFLE"), 9999, false, true);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 2);
+	SET_BLIP_AS_FRIENDLY(blip, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_SPAWN_COMPANION_CHIMP, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnCompanionChop.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnCompanionChop.cpp
@@ -18,6 +18,10 @@ static void OnStart()
 	SET_PED_HEARING_RANGE(ped, 9999.f);
 
 	SET_PED_AS_GROUP_MEMBER(ped, GET_PLAYER_GROUP(PLAYER_ID()));
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 2);
+	SET_BLIP_AS_FRIENDLY(blip, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_SPAWN_COMPANION_CHOP, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnCompanionRandom.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnCompanionRandom.cpp
@@ -27,6 +27,10 @@ static void OnStart()
 
 	SET_PED_ACCURACY(ped, 100);
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 2);
+	SET_BLIP_AS_FRIENDLY(blip, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_SPAWN_COMPANION_RANDOM, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnHostileRandom.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnHostileRandom.cpp
@@ -36,6 +36,10 @@ static void OnStart()
 
 	SET_PED_ACCURACY(ped, 100);
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_SPAWN_RANDOM_HOSTILE, OnStart);

--- a/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsSpawnImpotentRage.cpp
@@ -33,6 +33,10 @@ static void OnStart()
 	TASK_COMBAT_PED(ped, playerPed, 0, 16);
 
 	SET_PED_FIRING_PATTERN(ped, 0xC6EE6B4C);
+	
+	Blip blip = ADD_BLIP_FOR_ENTITY(ped);
+	SET_BLIP_COLOUR(blip, 1);
+	SET_BLIP_AS_FRIENDLY(blip, false);
 
 	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
 	{


### PR DESCRIPTION
 Pretty self-explanatory. It only adds blips to peds that don’t have one by default. Hostile peds have a red blip and companions have green blips.