### PR TITLE
(improvement:Player) Add Vector3 overload for TeleportPlayer

### DIFF
--- a/ChaosMod/Util/Player.h
+++ b/ChaosMod/Util/Player.h
@@ -32,3 +32,8 @@ inline void TeleportPlayer(float x, float y, float z, bool noOffset = false)
 		SET_VEHICLE_FORWARD_SPEED(playerVeh, forwardSpeed);
 	}
 }
+
+inline void TeleportPlayer(Vector3 coords, bool noOffset = false)
+{
+	TeleportPlayer(coords.x, coords.y, coords.z, noOffset);
+}


### PR DESCRIPTION
- Adds a `void TeleportPlayer(Vector3 coords, bool noOffset)` override to the `TeleportPlayer` methods
  - Allows for using a `Vector3` to define player coords. Useful for "random" teleport lists, such as proposed by #234 

Might not be worth merging immediately, short of going through existing `TeleportPlayer` calls and "updating" them to use this overload?