### PR TITLE
Add Effect: Virtual Reality

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="Effects\db\Misc\MiscLag.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsMercenaries.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscOilLeaks.cpp" />
+    <ClCompile Include="Effects\db\Player\PlayerVR.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsReplaceVehicle.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsGunsmoke.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsCatGuns.cpp" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -250,6 +250,7 @@ enum EffectType
 	EFFECT_PLAYER_DEAD_EYE,
 	EFFECT_PLAYER_QUAKE_FOV,
     EFFECT_PLAYER_HACKING,
+	EFFECT_PLAYER_VR,
 	_EFFECT_ENUM_MAX
 };
 
@@ -514,4 +515,5 @@ const std::unordered_map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_VEH_TURN_RIGHT, {"Everyone Turn Right", "veh_turnright", true, {}, true}},
     {EFFECT_PEDS_BUSBOIS, {"Bus Bois", "peds_busbois"}},
     {EFFECT_PLAYER_HACKING, {"Realistic Hacking", "player_hacking"}},
+	{EFFECT_PLAYER_VR, {"Virtual Reality", "player_vr", true}}
 };

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -1,0 +1,67 @@
+#include <stdafx.h>
+
+/*
+* Effect by kolyaventuri
+*/
+
+static Ped clone;
+static Vector3 coords;
+static float heading;
+
+static void OnStart() {
+	Ped player = PLAYER_PED_ID();
+
+	// (kolyaventuri): Recall position
+	heading = GET_ENTITY_HEADING(player);
+	coords = GET_ENTITY_COORDS(player, true);
+
+	// (kolyaventuri): Create clone
+	Hash relationshipGroup;
+	ADD_RELATIONSHIP_GROUP("_COMPANION_CLONE_FRIENDLY", &relationshipGroup);
+	SET_RELATIONSHIP_BETWEEN_GROUPS(0, relationshipGroup, GET_HASH_KEY("PLAYER"));
+	SET_RELATIONSHIP_BETWEEN_GROUPS(0, GET_HASH_KEY("PLAYER"), relationshipGroup);
+
+	clone = CLONE_PED(player, heading, false , true);
+	SET_ENTITY_INVINCIBLE(clone, true);
+
+	SET_PED_RELATIONSHIP_GROUP_HASH(clone, relationshipGroup);
+	FREEZE_ENTITY_POSITION(clone, true);
+}
+
+static void OnTick() {
+	Ped player = PLAYER_PED_ID();
+
+	// (kolyaventuri): Replicate weapon
+	GIVE_WEAPON_TO_PED(clone, GET_SELECTED_PED_WEAPON(player), 9999, true, true);
+
+	// (kolyaventuri): Force first person
+
+	SET_CINEMATIC_MODE_ACTIVE(false);
+
+	SET_FOLLOW_PED_CAM_VIEW_MODE(4);
+	SET_FOLLOW_VEHICLE_CAM_VIEW_MODE(4);
+	SET_FOLLOW_VEHICLE_CAM_ZOOM_LEVEL(4);
+
+	DISABLE_CONTROL_ACTION(0, 0, true);
+}
+
+static void OnStop() {
+	Ped player = PLAYER_PED_ID();
+
+	// (kolyaventuri): Snap player back to their original position
+	TeleportPlayer(coords);
+	SET_ENTITY_HEADING(player, heading);
+
+	// (kolyaventuri): Clean up clone
+	SET_ENTITY_INVINCIBLE(clone, false);
+	SET_ENTITY_HEALTH(clone, 0, 0);
+	SET_ENTITY_ALPHA(clone, 0, true);
+	SET_PED_AS_NO_LONGER_NEEDED(&clone);
+	DELETE_PED(&clone);
+
+	// (kolyaventuri): Clean up FP
+	SET_FOLLOW_PED_CAM_VIEW_MODE(1);
+	SET_FOLLOW_VEHICLE_CAM_VIEW_MODE(1);
+}
+
+static RegisterEffect registerEffect(EFFECT_PLAYER_VR, OnStart, OnStop, OnTick);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -39,10 +39,27 @@ static void OnStart() {
 		Vehicle veh = GET_VEHICLE_PED_IS_IN(player, false);
 		Hash model = GET_ENTITY_MODEL(veh);
 		Vector3 loc = GET_ENTITY_COORDS(veh, true);
+		int colors = GET_VEHICLE_COLOUR_COMBINATION(veh);
+
 		cloneVeh = CREATE_VEHICLE(model, loc.x, loc.y, loc.z, GET_ENTITY_HEADING(veh), false, false, 0);
+		SET_VEHICLE_COLOUR_COMBINATION(cloneVeh, colors);
+		SET_ENTITY_INVINCIBLE(cloneVeh, true);
+		SET_ENTITY_NO_COLLISION_ENTITY(cloneVeh, veh, false);
+		
+		// Find seat player is in
+		int maxSeats = GET_VEHICLE_MODEL_NUMBER_OF_SEATS(model);
+		int vehicleSeat = 0;
+		for (int i = 0; i < maxSeats; i++) {
+			if (GET_PED_IN_VEHICLE_SEAT(veh, i, false) == player) {
+				vehicleSeat = i;
+				break;
+			}
+		}
+
+		SET_PED_INTO_VEHICLE(clone, cloneVeh, vehicleSeat);
 	}
 
-	// (kolyaventuri): Apply camera effects
+	// (kolyaventuri): Apply camera effectsf
 	if (GET_TIMECYCLE_TRANSITION_MODIFIER_INDEX() == -1 && GET_TIMECYCLE_MODIFIER_INDEX() == -1)
 	{
 		SET_TRANSITION_TIMECYCLE_MODIFIER("secret_camera", 1.5f);
@@ -79,11 +96,10 @@ static void OnStop() {
 
 	// (kolyaventuri): Clean up clone
 	SET_ENTITY_AS_MISSION_ENTITY(clone, 0, 0);
-	SET_PED_AS_NO_LONGER_NEEDED(&clone);
 	DELETE_PED(&clone);
 
-	SET_ENTITY_AS_NO_LONGER_NEEDED(&cloneVeh);
-	DELETE_ENTITY(&cloneVeh);
+	SET_ENTITY_AS_MISSION_ENTITY(cloneVeh, true, true);
+	DELETE_VEHICLE(&cloneVeh);
 
 	// (kolyaventuri): Clean up FP
 	SET_FOLLOW_PED_CAM_VIEW_MODE(1);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -7,6 +7,7 @@
 static Ped clone;
 static Vector3 coords;
 static float heading;
+static Vector3 rot;
 
 static void OnStart() {
 	Ped player = PLAYER_PED_ID();
@@ -23,6 +24,7 @@ static void OnStart() {
 
 	clone = CLONE_PED(player, heading, false , true);
 	SET_ENTITY_INVINCIBLE(clone, true);
+	rot = GET_ENTITY_ROTATION(clone, 0);
 
 	SET_PED_RELATIONSHIP_GROUP_HASH(clone, relationshipGroup);
 	FREEZE_ENTITY_POSITION(clone, true);
@@ -59,6 +61,7 @@ static void OnStop() {
 	// (kolyaventuri): Snap player back to their original position
 	TeleportPlayer(coords);
 	SET_ENTITY_HEADING(player, heading);
+	SET_ENTITY_ROTATION(player, rot.x, rot.y, rot.z, 0, 1);
 	AUDIO::PLAY_SOUND_FRONTEND(-1, "1st_Person_Transition", "PLAYER_SWITCH_CUSTOM_SOUNDSET", 1);
 
 	// (kolyaventuri): Clean up clone

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -8,6 +8,7 @@ static Ped clone;
 static Vector3 coords;
 static float heading;
 static Vector3 rot;
+static Vehicle cloneVeh;
 
 static void OnStart() {
 	Ped player = PLAYER_PED_ID();
@@ -15,19 +16,31 @@ static void OnStart() {
 	// (kolyaventuri): Recall position
 	heading = GET_ENTITY_HEADING(player);
 	coords = GET_ENTITY_COORDS(player, true);
+	rot = GET_ENTITY_ROTATION(player, 0);
 
-	// (kolyaventuri): Create clone
-	Hash relationshipGroup;
-	ADD_RELATIONSHIP_GROUP("_COMPANION_CLONE_FRIENDLY", &relationshipGroup);
-	SET_RELATIONSHIP_BETWEEN_GROUPS(0, relationshipGroup, GET_HASH_KEY("PLAYER"));
-	SET_RELATIONSHIP_BETWEEN_GROUPS(0, GET_HASH_KEY("PLAYER"), relationshipGroup);
+	// (kolyaventuri): Create clone. CLONE_PED wasn't playing nice with entity deletion
+	int type = GET_PED_TYPE(player);
+	Hash model = GET_ENTITY_MODEL(player);
+	clone = CreatePoolPed(type, model, coords.x, coords.y, coords.z, heading);
+	CLONE_PED_TO_TARGET(player, clone); // Ensure that clone looks like player
 
-	clone = CLONE_PED(player, heading, false , true);
+	// (kolyaventuri): Fix an issue where the clone is placed above the player
+	float groundZ = coords.z;
+	GET_GROUND_Z_FOR_3D_COORD(coords.x, coords.y, coords.z, &groundZ, 0, 0);
+	coords.z = groundZ;
+	
+	SET_ENTITY_COORDS(clone, coords.x, coords.y, coords.z, 0, 0, 0, 1);
+	SET_ENTITY_ROTATION(clone, rot.x, rot.y, rot.z, 0, 1);
 	SET_ENTITY_INVINCIBLE(clone, true);
-	rot = GET_ENTITY_ROTATION(clone, 0);
-
-	SET_PED_RELATIONSHIP_GROUP_HASH(clone, relationshipGroup);
 	FREEZE_ENTITY_POSITION(clone, true);
+
+	// (kolyaventuri): Handle cars
+	if (IS_PED_IN_ANY_VEHICLE(player, false)) {
+		Vehicle veh = GET_VEHICLE_PED_IS_IN(player, false);
+		Hash model = GET_ENTITY_MODEL(veh);
+		Vector3 loc = GET_ENTITY_COORDS(veh, true);
+		cloneVeh = CREATE_VEHICLE(model, loc.x, loc.y, loc.z, GET_ENTITY_HEADING(veh), false, false, 0);
+	}
 
 	// (kolyaventuri): Apply camera effects
 	if (GET_TIMECYCLE_TRANSITION_MODIFIER_INDEX() == -1 && GET_TIMECYCLE_MODIFIER_INDEX() == -1)
@@ -65,11 +78,12 @@ static void OnStop() {
 	AUDIO::PLAY_SOUND_FRONTEND(-1, "1st_Person_Transition", "PLAYER_SWITCH_CUSTOM_SOUNDSET", 1);
 
 	// (kolyaventuri): Clean up clone
-	SET_ENTITY_INVINCIBLE(clone, false);
-	SET_ENTITY_HEALTH(clone, 0, 0);
-	SET_ENTITY_ALPHA(clone, 0, true);
+	SET_ENTITY_AS_MISSION_ENTITY(clone, 0, 0);
 	SET_PED_AS_NO_LONGER_NEEDED(&clone);
 	DELETE_PED(&clone);
+
+	SET_ENTITY_AS_NO_LONGER_NEEDED(&cloneVeh);
+	DELETE_ENTITY(&cloneVeh);
 
 	// (kolyaventuri): Clean up FP
 	SET_FOLLOW_PED_CAM_VIEW_MODE(1);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -26,6 +26,12 @@ static void OnStart() {
 
 	SET_PED_RELATIONSHIP_GROUP_HASH(clone, relationshipGroup);
 	FREEZE_ENTITY_POSITION(clone, true);
+
+	// (kolyaventuri): Apply camera effects
+	if (GET_TIMECYCLE_TRANSITION_MODIFIER_INDEX() == -1 && GET_TIMECYCLE_MODIFIER_INDEX() == -1)
+	{
+		SET_TRANSITION_TIMECYCLE_MODIFIER("secret_camera", 1.5f);
+	}
 }
 
 static void OnTick() {
@@ -62,6 +68,9 @@ static void OnStop() {
 	// (kolyaventuri): Clean up FP
 	SET_FOLLOW_PED_CAM_VIEW_MODE(1);
 	SET_FOLLOW_VEHICLE_CAM_VIEW_MODE(1);
+
+	// (kolyaventuri): Clear camera effects
+	CLEAR_TIMECYCLE_MODIFIER();
 }
 
 static RegisterEffect registerEffect(EFFECT_PLAYER_VR, OnStart, OnStop, OnTick);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -32,6 +32,8 @@ static void OnStart() {
 	{
 		SET_TRANSITION_TIMECYCLE_MODIFIER("secret_camera", 1.5f);
 	}
+
+	AUDIO::PLAY_SOUND_FRONTEND(-1, "1st_Person_Transition", "PLAYER_SWITCH_CUSTOM_SOUNDSET", 0);
 }
 
 static void OnTick() {
@@ -57,6 +59,7 @@ static void OnStop() {
 	// (kolyaventuri): Snap player back to their original position
 	TeleportPlayer(coords);
 	SET_ENTITY_HEADING(player, heading);
+	AUDIO::PLAY_SOUND_FRONTEND(-1, "1st_Person_Transition", "PLAYER_SWITCH_CUSTOM_SOUNDSET", 1);
 
 	// (kolyaventuri): Clean up clone
 	SET_ENTITY_INVINCIBLE(clone, false);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -45,7 +45,7 @@ static void OnStart() {
 		Vector3 loc = GET_ENTITY_COORDS(veh, true);
 		int colors = GET_VEHICLE_COLOUR_COMBINATION(veh);
 
-		cloneVeh = CREATE_VEHICLE(model, loc.x, loc.y, loc.z, GET_ENTITY_HEADING(veh), false, false, 0);
+		cloneVeh = CreatePoolVehicle(model, loc.x, loc.y, loc.z, GET_ENTITY_HEADING(veh));
 		SET_VEHICLE_COLOUR_COMBINATION(cloneVeh, colors);
 		SET_ENTITY_INVINCIBLE(cloneVeh, true);
 		SET_ENTITY_NO_COLLISION_ENTITY(cloneVeh, veh, false);

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -9,6 +9,7 @@ static Vector3 coords;
 static float heading;
 static Vector3 rot;
 static Vehicle cloneVeh;
+static int camModes[3] = {0,0,0};
 
 static void OnStart() {
 	Ped player = PLAYER_PED_ID();
@@ -17,6 +18,9 @@ static void OnStart() {
 	heading = GET_ENTITY_HEADING(player);
 	coords = GET_ENTITY_COORDS(player, true);
 	rot = GET_ENTITY_ROTATION(player, 0);
+	camModes[0] = GET_FOLLOW_PED_CAM_VIEW_MODE();
+	camModes[1] = GET_FOLLOW_VEHICLE_CAM_VIEW_MODE();
+	camModes[2] = GET_FOLLOW_VEHICLE_CAM_ZOOM_LEVEL();
 
 	// (kolyaventuri): Create clone. CLONE_PED wasn't playing nice with entity deletion
 	int type = GET_PED_TYPE(player);
@@ -102,8 +106,9 @@ static void OnStop() {
 	DELETE_VEHICLE(&cloneVeh);
 
 	// (kolyaventuri): Clean up FP
-	SET_FOLLOW_PED_CAM_VIEW_MODE(1);
-	SET_FOLLOW_VEHICLE_CAM_VIEW_MODE(1);
+	SET_FOLLOW_PED_CAM_VIEW_MODE(camModes[0]);
+	SET_FOLLOW_VEHICLE_CAM_VIEW_MODE(camModes[1]);
+	SET_FOLLOW_VEHICLE_CAM_ZOOM_LEVEL(camModes[2]);
 
 	// (kolyaventuri): Clear camera effects
 	CLEAR_TIMECYCLE_MODIFIER();

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -285,6 +285,7 @@ namespace ConfigApp
             EFFECT_PLAYER_DEAD_EYE,
             EFFECT_PLAYER_QUAKE_FOV,
             EFFECT_PLAYER_HACKING,
+            EFFECT_PLAYER_VR,
             _EFFECT_ENUM_MAX
         }
 
@@ -535,6 +536,7 @@ namespace ConfigApp
             {EffectType.EFFECT_PEDS_BUSBOIS,  new EffectInfo("Bus Bois", EffectCategory.PEDS, "peds_busbois")},
             {EffectType.EFFECT_PLAYER_DEAD_EYE,  new EffectInfo("Dead Eye", EffectCategory.PLAYER, "player_dead_eye", true)},
             {EffectType.EFFECT_PLAYER_HACKING, new EffectInfo("Realistic Hacking", EffectCategory.PLAYER, "player_hacking")},
+            {EffectType.EFFECT_PLAYER_VR, new EffectInfo("Virtual Reality", EffectCategory.PLAYER, "player_vr", true)}
         };
     }
 }


### PR DESCRIPTION
**Virtual Reality**
- Clones player (with or without car, depending)
  - Clone is invincible frozen in spot
- Camera / scanline effect is applied to be a "screen"
- Player can continue as normal, forced into first person
- When timer is up, play is snapped back to their starting location, as though they have been controlling a character in VR

Other ideas:
- When effect starts, TP the actual player such that they're facing their clone, to make it more obvious what's happening (need to take into account walls / oob areas)
- Add some kind of goggles or helmet to the clone, to make it clearer that it's a virtual reality experience?
- Allow clone to take damage? If they die, the player dies
- Copy player movement / aiming to clone (keep them in place)
- Don't allow the clone to be aggressive? I've noticed a quirk when the clone gets attacked by police, it can start trying to fire back? 0 ammo weaponry might mitigate this on its own

fixes #276 