### PR TITLE
[WIP] Update Effect: VR

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -75,6 +75,12 @@ static void OnStart() {
 static void OnTick() {
 	Ped player = PLAYER_PED_ID();
 
+	// (kolyaventuri): Face the same direction as the player
+	if (!IS_PED_IN_ANY_VEHICLE(player, false)) {
+		float heading = GET_ENTITY_HEADING(player);
+		SET_ENTITY_HEADING(clone, heading);
+	}
+
 	// (kolyaventuri): Replicate weapon
 	GIVE_WEAPON_TO_PED(clone, GET_SELECTED_PED_WEAPON(player), 0, true, true);
 

--- a/ChaosMod/Effects/db/Player/PlayerVR.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerVR.cpp
@@ -76,7 +76,7 @@ static void OnTick() {
 	Ped player = PLAYER_PED_ID();
 
 	// (kolyaventuri): Replicate weapon
-	GIVE_WEAPON_TO_PED(clone, GET_SELECTED_PED_WEAPON(player), 9999, true, true);
+	GIVE_WEAPON_TO_PED(clone, GET_SELECTED_PED_WEAPON(player), 0, true, true);
 
 	// (kolyaventuri): Force first person
 


### PR DESCRIPTION
- Gives clone 0 bullets so they can't attack
- Maintain the same heading as the player, emulating the way you turn in VR

TODO:
- Add some sort of helmet to the player.. wanted to use like the "[Black Dual Lens](https://forge.plebmasters.de/clothes/NzUxMDc4Mjc)" or something, however `SET_PED_COMPONENT_VARIATION(clone, 0, 96, 0, 0);` doesn't seem to want to work
- See if there's a way to get AI to ignore a specific ped, not the player. If the clone can just, exist but be ignored, that would be best
- Test for OOB so we can teleport the player so they can see their own clone, to sell the effect a bit more