### PR TITLE
Fix 'Need For Speed'

### DIFF
--- a/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpeedMin.cpp
@@ -51,7 +51,7 @@ static void OnTick()
 
             m_lastVeh = 0;
             m_timeReserve = WAIT_TIME;
-            m_lastTick = GetTickCount64();
+            m_lastTick = GET_GAME_TIMER();
 
             return;
         }
@@ -60,7 +60,7 @@ static void OnTick()
 
         float minSpeed = GET_VEHICLE_MODEL_ESTIMATED_MAX_SPEED(GET_ENTITY_MODEL(veh)) * SPEED_THRESHOLD;
         float speedms = GET_ENTITY_SPEED(veh);
-        DWORD64 currentTick = GetTickCount64();
+        DWORD64 currentTick = GET_GAME_TIMER();
         DWORD64 tickDelta = currentTick - m_lastTick;
         int overlaycolor = 0;
         if (speedms < minSpeed)
@@ -131,7 +131,7 @@ static void OnStart()
         WAIT(0);
     }
     m_enteredVehicle = false;
-    m_lastTick = GetTickCount64();
+    m_lastTick = GET_GAME_TIMER();
     m_lastVeh = 0;
     m_timeReserve = WAIT_TIME;
 }


### PR DESCRIPTION
Changes from https://github.com/gta-chaos-mod/ChaosModV/pull/202 has been reverted for this effect via https://github.com/gta-chaos-mod/ChaosModV/commit/cfaeab7a3e747e0b1ece49809e86740ca9d8c6f6
-> this results in the "Need For Speed" Timer running while paused 
Fixes https://github.com/gta-chaos-mod/ChaosModV/issues/277