### PR TITLE
Fixed Portal Guns

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsTPGuns.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsTPGuns.cpp
@@ -69,7 +69,7 @@ static void OnTick()
 				Vector3 vel = GET_ENTITY_VELOCITY(toTeleport);
 				float forward = GET_ENTITY_SPEED(toTeleport);
 
-				SET_ENTITY_COORDS(toTeleport, impactCoords.x, impactCoords.y, impactCoords.z, false, false, false, false);
+				SET_ENTITY_COORDS(toTeleport, impactCoords.x, impactCoords.y, impactCoords.z, true, true, true, false);
 				SET_ENTITY_VELOCITY(toTeleport, vel.x, vel.y, vel.z);
 
 				if (IS_ENTITY_A_VEHICLE(toTeleport))


### PR DESCRIPTION
Entities need to keep rotation to prevent double shooting