### PR TITLE
[New Effect] Nap Time

### DIFF
--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -257,6 +257,7 @@ enum EffectType
 	EFFECT_HIGH_PITCH,
 	EFFECT_NO_SKY,
 	EFFECT_PLAYER_GTA_2,
+	EFFECT_NAP_TIME,
 	_EFFECT_ENUM_MAX
 };
 
@@ -527,5 +528,6 @@ const std::unordered_map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_PLAYER_VR, {"Virtual Reality", "player_vr", true, {}, true}},
 	{EFFECT_HIGH_PITCH, {"High Pitch", "misc_highpitch", true, { EFFECT_GAMESPEED_X02, EFFECT_GAMESPEED_X05 }}},
 	{EFFECT_NO_SKY, {"No Sky", "misc_nosky", true}},
-	{EFFECT_PLAYER_GTA_2, {"GTA 2", "player_gta_2", true, { EFFECT_PLAYER_QUAKE_FOV, EFFECT_FLIP_CAMERA }, true}}
+	{EFFECT_PLAYER_GTA_2, {"GTA 2", "player_gta_2", true, { EFFECT_PLAYER_QUAKE_FOV, EFFECT_FLIP_CAMERA }, true}},
+	{EFFECT_NAP_TIME, { "It's Nap Time", "peds_sleep", true }}
 };

--- a/ChaosMod/Effects/db/PedsNapTime.cpp
+++ b/ChaosMod/Effects/db/PedsNapTime.cpp
@@ -1,0 +1,37 @@
+#include <stdafx.h>
+
+/*
+	Effect by Eli Rickard
+*/
+
+static void OnStop()
+{
+	REMOVE_ANIM_DICT("amb@world_human_bum_slumped@male@laying_on_left_side@idle_a");
+}
+
+static void OnTick()
+{
+	SET_CLOCK_TIME(21, 30, 50);
+
+	for (auto ped : GetAllPeds())
+	{
+		if (IS_PED_IN_ANY_VEHICLE(ped, true))
+		{
+			Vehicle pedVeh = GET_VEHICLE_PED_IS_IN(ped, true);
+			TASK_LEAVE_VEHICLE(ped, pedVeh, 256);
+			BRING_VEHICLE_TO_HALT(pedVeh, 0.1f, 10, 0);
+		}
+	}
+
+	REQUEST_ANIM_DICT("amb@world_human_bum_slumped@male@laying_on_left_side@idle_a");
+
+	for (auto ped : GetAllPeds())
+	{
+		if (!IS_PED_A_PLAYER(ped) && !IS_ENTITY_PLAYING_ANIM(ped, "amb@world_human_bum_slumped@male@laying_on_left_side@idle_a", "idle_b", 3))
+		{
+			TASK_PLAY_ANIM(ped, "amb@world_human_bum_slumped@male@laying_on_left_side@idle_a", "idle_b", 4.0f, -4.0f, -1.f, 1, 0.f, true, true, true);
+		}
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_NAP_TIME, nullptr, OnStop, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -292,6 +292,7 @@ namespace ConfigApp
             EFFECT_HIGH_PITCH,
             EFFECT_NO_SKY,
             EFFECT_PLAYER_GTA_2,
+            EFFECT_NAP_TIME,
             _EFFECT_ENUM_MAX
         }
 
@@ -548,7 +549,8 @@ namespace ConfigApp
             {EffectType.EFFECT_PLAYER_VR, new EffectInfo("Virtual Reality", EffectCategory.PLAYER, "player_vr", true, true)},
             {EffectType.EFFECT_HIGH_PITCH, new EffectInfo("High Pitch", EffectCategory.MISC, "misc_highpitch", true)},
             {EffectType.EFFECT_NO_SKY, new EffectInfo("No Sky", EffectCategory.MISC, "misc_nosky", true)},
-            {EffectType.EFFECT_PLAYER_GTA_2, new EffectInfo("GTA 2", EffectCategory.PLAYER, "player_gta_2", true, true)}
+            {EffectType.EFFECT_PLAYER_GTA_2, new EffectInfo("GTA 2", EffectCategory.PLAYER, "player_gta_2", true, true)},
+            {EffectType.EFFECT_NAP_TIME, new EffectInfo("It's Nap Time", EffectCategory.PEDS, "peds_sleep", true)}
         };
     }
 }


### PR DESCRIPTION
Sets time to night, Forces all peds and player to halt vehicle (if in one) and get out, forces all peds (excluding player) to perform sleep animation for the duration of the effect. It's on screen name is "It's Nap Time"

It is timed as a "Long" effect.

(This effect and my Where's the funeral PR are being redone as they were made in the master branch of my fork, which would inhibit further effects creation)