### PR TITLE
New effect: Crumbling Vehicles

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="Effects\db\Peds\PedsMercenaries.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscOilLeaks.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerVR.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsCrumble.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsReplaceVehicle.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsGunsmoke.cpp" />
     <ClCompile Include="Effects\db\Peds\PedsCatGuns.cpp" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -259,6 +259,7 @@ enum EffectType
 	EFFECT_NO_SKY,
 	EFFECT_PLAYER_GTA_2,
 	EFFECT_PEDS_TPOSE,
+	EFFECT_VEHS_CRUMBLE,
 	_EFFECT_ENUM_MAX
 };
 
@@ -532,4 +533,5 @@ const std::unordered_map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_NO_SKY, {"No Sky", "misc_nosky", true}},
 	{EFFECT_PLAYER_GTA_2, {"GTA 2", "player_gta_2", true, { EFFECT_PLAYER_QUAKE_FOV, EFFECT_FLIP_CAMERA }, true}},
 	{EFFECT_PEDS_TPOSE, {"GTA 2077", "peds_tpose", true, { EFFECT_IN_THE_HOOD, EFFECT_SLIDY_PEDS }, true}},
+	{EFFECT_VEHS_CRUMBLE, {"Crumbling Vehicles", "vehs_crumble", true, {}, true}}
 };

--- a/ChaosMod/Effects/db/Vehs/VehsCrumble.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsCrumble.cpp
@@ -1,0 +1,20 @@
+/*
+	Effect by Juhana
+*/
+
+#include <stdafx.h>
+
+static void OnTick()
+{
+	std::vector<Vehicle> vehs = GetAllVehs();
+	int vehicleAmount = static_cast<int>(vehs.size());
+
+	if (vehicleAmount > 0)
+	{
+		// apply random damage to a random part of a random vehicle
+		Vehicle veh = vehs[g_random.GetRandomInt(0, vehicleAmount - 1)];
+		SET_VEHICLE_DAMAGE(veh, g_random.GetRandomFloat(-1.f, 1.f), g_random.GetRandomFloat(-1.f, 1.f), g_random.GetRandomFloat(-1.f, 1.f), g_random.GetRandomFloat(1000.f, 10000.f), g_random.GetRandomFloat(100.f, 1000.f), true);
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_VEHS_CRUMBLE, nullptr, nullptr, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -294,6 +294,7 @@ namespace ConfigApp
             EFFECT_NO_SKY,
             EFFECT_PLAYER_GTA_2,
             EFFECT_PEDS_TPOSE,
+            EFFECT_VEHS_CRUMBLE,
             _EFFECT_ENUM_MAX
         }
 
@@ -552,7 +553,8 @@ namespace ConfigApp
             {EffectType.EFFECT_HIGH_PITCH, new EffectInfo("High Pitch", EffectCategory.MISC, "misc_highpitch", true)},
             {EffectType.EFFECT_NO_SKY, new EffectInfo("No Sky", EffectCategory.MISC, "misc_nosky", true)},
             {EffectType.EFFECT_PLAYER_GTA_2, new EffectInfo("GTA 2", EffectCategory.PLAYER, "player_gta_2", true, true)},
-            {EffectType.EFFECT_PEDS_TPOSE, new EffectInfo("GTA 2077", EffectCategory.PEDS, "peds_tpose", true, true)}
+            {EffectType.EFFECT_PEDS_TPOSE, new EffectInfo("GTA 2077", EffectCategory.PEDS, "peds_tpose", true, true)},
+            {EffectType.EFFECT_VEHS_CRUMBLE, new EffectInfo("Crumbling Vehicles", EffectCategory.VEHICLE, "vehs_crumble", true, true)}
         };
     }
 }


### PR DESCRIPTION
Causes impact damage to random parts of vehicles which deforms them, breaks windows and sometimes removes wheels.

Damage needs to be done gradually, it doesn't seem to work very well if you apply damage to too many vehicles on the same frame.