### PR TITLE
Improved effect Midas Touch

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
@@ -13,6 +13,7 @@ static void OnTick()
 	{
 		cE = GET_VEHICLE_PED_IS_IN(playerPed, false);
 		SET_VEHICLE_COLOURS(cE, 158, 158); // 158 = Pure Gold
+		SET_VEHICLE_EXTRA_COLOURS(cE, 160, 158);
 	}
 
 	for (Vehicle veh : GetAllVehs())
@@ -20,6 +21,7 @@ static void OnTick()
 		if (IS_ENTITY_TOUCHING_ENTITY(cE, veh))
 		{
 			SET_VEHICLE_COLOURS(veh, 158, 158); // 158 = Pure Gold
+			SET_VEHICLE_EXTRA_COLOURS(veh, 160, 158);
 		}
 	}
 


### PR DESCRIPTION
Before: Only the primary and secondary color got changed to Pure Gold. Because the overwhelming majority of vehicles don't have a bright yellow pearlescent, the resulting vehicles looked like poop.  
After: The pearlescent and rim color get changed as well, now vehicles should look properly golden.