### PR TITLE
Added Effect 'Cruise Control'

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -285,6 +285,7 @@
     <ClCompile Include="Effects\db\Vehs\VehsTirePoppin.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsSlipperyVehs.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsSpawner.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsCruiseControl.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsSpawnIESultan.cpp" />
     <ClCompile Include="Effects\db\Weather\WeatherController.cpp" />
     <ClCompile Include="LuaManager.cpp" />

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -269,6 +269,7 @@ enum EffectType
 	EFFECT_MISC_FPS_LIMIT,
 	EFFECT_META_NO_CHAOS,
 	EFFECT_PEDS_ROASTING,
+	EFFECT_VEHS_CRUISE_CONTROL,
 	_EFFECT_ENUM_MAX
 };
 
@@ -558,5 +559,6 @@ const std::unordered_map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_VEHS_CRUMBLE, {"Crumbling Vehicles", "vehs_crumble", true, {}, true}},
 	{EFFECT_MISC_FPS_LIMIT, {"Console Experience", "misc_fps_limit", true, {}, true}},
 	{EFFECT_META_NO_CHAOS, {"No Chaos", "meta_nochaos", true, { EFFECT_META_HIDE_CHAOS_UI }, false, EffectExecutionType::META}},
-	{EFFECT_PEDS_ROASTING, {"Roasting", "peds_roasting", true, {}, true}}
+	{EFFECT_PEDS_ROASTING, {"Roasting", "peds_roasting", true, {}, true}},
+	{EFFECT_VEHS_CRUISE_CONTROL, {"Cruise Control", "vehs_cruise_control", true}},
 };

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -560,5 +560,5 @@ const std::unordered_map<EffectType, EffectInfo> g_effectsMap =
 	{EFFECT_MISC_FPS_LIMIT, {"Console Experience", "misc_fps_limit", true, {}, true}},
 	{EFFECT_META_NO_CHAOS, {"No Chaos", "meta_nochaos", true, { EFFECT_META_HIDE_CHAOS_UI }, false, EffectExecutionType::META}},
 	{EFFECT_PEDS_ROASTING, {"Roasting", "peds_roasting", true, {}, true}},
-	{EFFECT_VEHS_CRUISE_CONTROL, {"Cruise Control", "vehs_cruise_control", true}},
+	{EFFECT_VEHS_CRUISE_CONTROL, {"Cruise Control", "vehs_cruise_control", true, {}, true}},
 };

--- a/ChaosMod/Effects/db/Vehs/VehsCruiseControl.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsCruiseControl.cpp
@@ -1,0 +1,39 @@
+/*
+	Effect by Last0xygen
+*/
+
+#include <stdafx.h>
+
+float currentVel = -1;
+
+static void OnStop()
+{
+	currentVel = -1;
+}
+
+static void OnTick()
+{
+	Ped player = PLAYER_PED_ID();
+	if (IS_PED_IN_ANY_VEHICLE(player, false))
+	{
+		Vehicle veh = GET_VEHICLE_PED_IS_IN(player, false);
+		if (IS_VEHICLE_ON_ALL_WHEELS(veh))
+		{
+			float speed = GET_ENTITY_SPEED(veh);
+			if (speed > currentVel || speed < currentVel / 2 || speed < 1)
+			{
+				currentVel = speed;
+			}
+			else if (speed < currentVel)
+			{
+				SET_VEHICLE_FORWARD_SPEED(veh, currentVel);
+			}
+		}
+	}
+	else 
+	{
+		currentVel = -1;
+	}
+}
+
+static RegisterEffect registerEffect(EFFECT_VEHS_CRUISE_CONTROL, nullptr, OnStop, OnTick);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -575,7 +575,7 @@ namespace ConfigApp
             {EffectType.EFFECT_MISC_FPS_LIMIT, new EffectInfo("Console Experience", EffectCategory.MISC, "misc_fps_limit", true, true)},
             {EffectType.EFFECT_META_NO_CHAOS, new EffectInfo("No Chaos", EffectCategory.META, "meta_nochaos", true)},
             {EffectType.EFFECT_PEDS_ROASTING, new EffectInfo("Roasting", EffectCategory.PEDS, "peds_roasting", true, true)},
-			{EffectType.EFFECT_VEHS_CRUISE_CONTROL, new EffectInfo("Cruise Control", EffectCategory.VEHICLE, "vehs_cruise_control", true)},
+			{EffectType.EFFECT_VEHS_CRUISE_CONTROL, new EffectInfo("Cruise Control", EffectCategory.VEHICLE, "vehs_cruise_control", true, true)},
         };
     }
 }

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -305,6 +305,7 @@ namespace ConfigApp
             EFFECT_MISC_FPS_LIMIT,
             EFFECT_META_NO_CHAOS,
             EFFECT_PEDS_ROASTING,
+			EFFECT_VEHS_CRUISE_CONTROL,
             _EFFECT_ENUM_MAX
         }
 
@@ -573,7 +574,8 @@ namespace ConfigApp
             {EffectType.EFFECT_VEHS_CRUMBLE, new EffectInfo("Crumbling Vehicles", EffectCategory.VEHICLE, "vehs_crumble", true, true)},
             {EffectType.EFFECT_MISC_FPS_LIMIT, new EffectInfo("Console Experience", EffectCategory.MISC, "misc_fps_limit", true, true)},
             {EffectType.EFFECT_META_NO_CHAOS, new EffectInfo("No Chaos", EffectCategory.META, "meta_nochaos", true)},
-            {EffectType.EFFECT_PEDS_ROASTING, new EffectInfo("Roasting", EffectCategory.PEDS, "peds_roasting", true, true)}
+            {EffectType.EFFECT_PEDS_ROASTING, new EffectInfo("Roasting", EffectCategory.PEDS, "peds_roasting", true, true)},
+			{EffectType.EFFECT_VEHS_CRUISE_CONTROL, new EffectInfo("Cruise Control", EffectCategory.VEHICLE, "vehs_cruise_control", true)},
         };
     }
 }


### PR DESCRIPTION
Fix https://github.com/gta-chaos-mod/ChaosModV/issues/818
Stops player vehicle from deceleration 