### PR TITLE
Minor fixes to Lag

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscLag.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscLag.cpp
@@ -47,6 +47,9 @@ static void OnTickLag()
 		}
 		else if (m_state == 3)
 		{
+			// save current camera heading to apply after teleporting
+			float camHeading = GET_GAMEPLAY_CAM_RELATIVE_HEADING();
+
 			for (const auto& pair : m_toTpPeds)
 			{
 				const Ped& ped = pair.first;
@@ -72,6 +75,11 @@ static void OnTickLag()
 				float heading = GET_ENTITY_HEADING(veh);
 				float forwardSpeed = GET_ENTITY_SPEED(veh);
 
+				// if the vehicle is reversing use a negative forward speed
+				if (GET_ENTITY_SPEED_VECTOR(veh, true).y < 0) {
+					forwardSpeed *= -1;
+				}
+
 				const Vector3& tpPos = pair.second;
 
 				SET_ENTITY_COORDS_NO_OFFSET(veh, tpPos.x, tpPos.y, tpPos.z, false, false, false);
@@ -83,6 +91,8 @@ static void OnTickLag()
 			}
 
 			m_toTpVehs.clear();
+
+			SET_GAMEPLAY_CAM_RELATIVE_HEADING(camHeading);
 		}
 	}
 }


### PR DESCRIPTION
* The speed of reversing vehicles was applied as forward speed after the lag teleport, causing them to start moving to the opposite direction. They'll now keep reversing after the lag.
* Maintains the player camera's orientation after the lag teleport, which fixes the issue where the camera would flip 180 degrees after the lag teleport when traveling in a fast vehicle.