### PR TITLE
CrashFix - Invalid GroupEffectCount

### DIFF
--- a/ChaosMod/Effects/Effect.h
+++ b/ChaosMod/Effects/Effect.h
@@ -168,12 +168,12 @@ private:
 		EffectGroupType effectGroupType = effectInfo.EffectGroupType;
 		if (effectGroupType != EffectGroupType::DEFAULT)
 		{
-			if (!g_effectGroupMemberCount[effectGroupType])
+			if (!g_allEffectGroupMemberCount[effectGroupType])
 			{
-				g_effectGroupMemberCount[effectGroupType] = 0;
+				g_allEffectGroupMemberCount[effectGroupType] = 0;
 			}
 
-			g_effectGroupMemberCount[effectGroupType]++;
+			g_allEffectGroupMemberCount[effectGroupType]++;
 		}
 	}
 

--- a/ChaosMod/Effects/EffectData.h
+++ b/ChaosMod/Effects/EffectData.h
@@ -28,6 +28,6 @@ inline float GetEffectWeight(const EffectData& effectData)
 	float effectWeight = effectData.Weight;
 
 	return effectGroupType != EffectGroupType::DEFAULT
-		? effectWeight / g_effectGroupMemberCount[effectGroupType] * g_effectGroups.at(effectGroupType).WeightMult
+		? effectWeight / g_currentEffectGroupMemberCount[effectGroupType] * g_effectGroups.at(effectGroupType).WeightMult
 		: effectWeight;
 }

--- a/ChaosMod/Effects/EffectGroups.h
+++ b/ChaosMod/Effects/EffectGroups.h
@@ -34,4 +34,5 @@ inline const std::unordered_map<EffectGroupType, EffectGroup> g_effectGroups
 	{EffectGroupType::WEATHER_CHANGE, {}},
 };
 
-inline std::unordered_map<EffectGroupType, int> g_effectGroupMemberCount;
+inline std::unordered_map<EffectGroupType, int> g_allEffectGroupMemberCount;
+inline std::unordered_map<EffectGroupType, int> g_currentEffectGroupMemberCount;

--- a/ChaosMod/Main.cpp
+++ b/ChaosMod/Main.cpp
@@ -20,6 +20,7 @@ std::array<int, 3> ParseColor(const std::string& colorText)
 static void ParseEffectsFile()
 {
 	g_enabledEffects.clear();
+	g_currentEffectGroupMemberCount = g_allEffectGroupMemberCount;
 
 	OptionsFile effectsFile("chaosmod/effects.ini");
 
@@ -73,7 +74,7 @@ static void ParseEffectsFile()
 		{
 			if (effectInfo.EffectGroupType != EffectGroupType::DEFAULT)
 			{
-				g_effectGroupMemberCount[effectInfo.EffectGroupType]--;
+				g_currentEffectGroupMemberCount[effectInfo.EffectGroupType]--;
 			}
 
 			continue;


### PR DESCRIPTION
While the groupeffect count gets set on the first start only, they get reduced every time the mod reads the config-file -> reducing the effect-weight to become negative -> crashing if that weight overweights all other effects