### PR TITLE
Exclude Snipers from 'Dead Eye'

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerDeadEye.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerDeadEye.cpp
@@ -26,7 +26,7 @@ static void OnTick()
 {
 	Ped player = PLAYER_PED_ID();
 	Hash weaponHash;
-	if (isBlocked || !GET_CURRENT_PED_WEAPON(player, &weaponHash, true) || GET_WEAPONTYPE_GROUP(weaponHash) == 0xD49321D4)
+	if (isBlocked || !GET_CURRENT_PED_WEAPON(player, &weaponHash, true) || GET_WEAPONTYPE_GROUP(weaponHash) == 0xD49321D4 || GET_WEAPONTYPE_GROUP(weaponHash) == 0xB7BBD827)
 	{
 		return;
 	}


### PR DESCRIPTION
the effect doesn't work properly with them and prevents them from shooting, this prevents the tagging part of the effect from activating with snipers