### PR TITLE
WIP: Fix "set player into random vehicle"

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerSetIntoRandomVeh.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerSetIntoRandomVeh.cpp
@@ -43,6 +43,30 @@ static void OnStart()
 		}
 
 		Vehicle targetVeh = vehs[g_random.GetRandomInt(0, vehs.size() - 1)];
+		Vector3 vehLocation = GET_ENTITY_COORDS(targetVeh, true);
+
+		float groundZ;
+		bool useGroundZ;
+		for (int i = 0; i < 100; i++)
+		{
+			float testZ = (i * 10.f) - 100.f;
+
+			if (i % 5 == 0)
+			{
+				WAIT(0);
+			}
+
+			useGroundZ = GET_GROUND_Z_FOR_3D_COORD(vehLocation.x, vehLocation.y, testZ, &groundZ, false, false);
+			if (useGroundZ)
+			{
+				break;
+			}
+		}
+		if (groundZ > vehLocation.z)
+		{
+			SET_ENTITY_COORDS(targetVeh, vehLocation.x, vehLocation.y, groundZ, 1, 0, 0, 1);
+		}
+		
 		Hash targetVehModel = GET_ENTITY_MODEL(targetVeh);
 		int targetVehMaxSeats = GET_VEHICLE_MODEL_NUMBER_OF_SEATS(targetVehModel);
 


### PR DESCRIPTION
- Resolves bug where "Set Player Into Random Vehicle" would sometimes TP the player under the map
  - Extremely simple, but just does a ground Z-level check and ensures that the vehicle selected does _not_ exist under the map in the given location

Known bugs:
- Sometimes the vehicle is above the map, but not properly loaded
- Sometimes the vehicles are above the map, but spawn in buildings