### PR TITLE
Fixed allied peds not attacking player during 'All Peds Attack Player' effect

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsAttackPlayer.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsAttackPlayer.cpp
@@ -39,7 +39,7 @@ static void OnTick()
 	}
 }
 
-static RegisterEffect registerEffect(EFFECT_PEDS_ATTACK_PLAYER, nullptr, OnStart, OnTick, EffectInfo
+static RegisterEffect registerEffect(EFFECT_PEDS_ATTACK_PLAYER, OnStart, nullptr, OnTick, EffectInfo
 	{
 		.Name = "All Peds Attack Player",
 		.Id = "peds_attackplayer",


### PR DESCRIPTION
The OnStart function was registered as the OnStop function of the effect, causing the relationship group to not be created until the effect ended, so every ped was put into a non-existent group. This still worked for already hostile or neutral peds, but allied peds would just flee the player instead of attacking.