### PR TITLE
Make vehicle color changing effects change tyre smoke color and reset enveff scale and dirt level.

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
@@ -39,8 +39,8 @@ static void OnTick()
 
 			SET_VEHICLE_COLOURS(veh, 158, 158); // 158 = Pure Gold
 			SET_VEHICLE_EXTRA_COLOURS(veh, 160, 158);
-			SET_VEHICLE_ENVEFF_SCALE(cE, 0.f);
-			SET_VEHICLE_DIRT_LEVEL(cE, 0.f);
+			SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+			SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 		}
 	}
 

--- a/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
@@ -12,6 +12,14 @@ static void OnTick()
 	if (IS_PED_IN_ANY_VEHICLE(playerPed, false))
 	{
 		cE = GET_VEHICLE_PED_IS_IN(playerPed, false);
+
+		TOGGLE_VEHICLE_MOD(cE, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(cE, 255, 215, 0);
+
+		// If the vehicle has a custom color, the effect won't work
+		CLEAR_VEHICLE_CUSTOM_PRIMARY_COLOUR(cE);
+		CLEAR_VEHICLE_CUSTOM_SECONDARY_COLOUR(cE);
+
 		SET_VEHICLE_COLOURS(cE, 158, 158); // 158 = Pure Gold
 		SET_VEHICLE_EXTRA_COLOURS(cE, 160, 158);
 		SET_VEHICLE_ENVEFF_SCALE(cE, 0.f);
@@ -22,6 +30,13 @@ static void OnTick()
 	{
 		if (IS_ENTITY_TOUCHING_ENTITY(cE, veh))
 		{
+			TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+			SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 255, 215, 0);
+
+			// If the vehicle has a custom color, the effect won't work
+			CLEAR_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh);
+			CLEAR_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh);
+
 			SET_VEHICLE_COLOURS(veh, 158, 158); // 158 = Pure Gold
 			SET_VEHICLE_EXTRA_COLOURS(veh, 160, 158);
 			SET_VEHICLE_ENVEFF_SCALE(cE, 0.f);

--- a/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMidasTouch.cpp
@@ -14,6 +14,8 @@ static void OnTick()
 		cE = GET_VEHICLE_PED_IS_IN(playerPed, false);
 		SET_VEHICLE_COLOURS(cE, 158, 158); // 158 = Pure Gold
 		SET_VEHICLE_EXTRA_COLOURS(cE, 160, 158);
+		SET_VEHICLE_ENVEFF_SCALE(cE, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(cE, 0.f);
 	}
 
 	for (Vehicle veh : GetAllVehs())
@@ -22,6 +24,8 @@ static void OnTick()
 		{
 			SET_VEHICLE_COLOURS(veh, 158, 158); // 158 = Pure Gold
 			SET_VEHICLE_EXTRA_COLOURS(veh, 160, 158);
+			SET_VEHICLE_ENVEFF_SCALE(cE, 0.f);
+			SET_VEHICLE_DIRT_LEVEL(cE, 0.f);
 		}
 	}
 

--- a/ChaosMod/Effects/db/Vehs/VehsColorController.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsColorController.cpp
@@ -4,6 +4,9 @@ static void OnTickRed()
 {
 	for (Vehicle veh : GetAllVehs())
 	{
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 255, 0, 0);
+
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 255, 0, 0);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 255, 0, 0);
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
@@ -24,6 +27,9 @@ static void OnTickBlue()
 {
 	for (Vehicle veh : GetAllVehs())
 	{
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 0, 0, 255);
+
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 0, 0, 255);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 0, 0, 255);
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
@@ -44,6 +50,9 @@ static void OnTickGreen()
 {
 	for (Vehicle veh : GetAllVehs())
 	{
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 0, 255, 0);
+
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 0, 255, 0);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 0, 255, 0);
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
@@ -64,6 +73,13 @@ static void OnTickChrome()
 {
 	for (Vehicle veh : GetAllVehs())
 	{
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 219, 226, 233);
+
+		// If the vehicle has a custom color, the effect won't work
+		CLEAR_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh);
+		CLEAR_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh);
+
 		SET_VEHICLE_COLOURS(veh, 120, 120);
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
 		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
@@ -124,6 +140,9 @@ static void OnTickPink()
 			flameByCar[veh] = handle;
 		}
 
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, 255, 0, 255);
+
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 255, 0, 255);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 255, 0, 255);
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
@@ -181,6 +200,9 @@ static void OnTickRainbow()
 
 		TOGGLE_VEHICLE_MOD(veh, 22, true);
 		_SET_VEHICLE_XENON_LIGHTS_COLOR(veh, headlightColor);
+
+		TOGGLE_VEHICLE_MOD(veh, 20, true); // Enable custom tyre smoke
+		SET_VEHICLE_TYRE_SMOKE_COLOR(veh, r, g, b);
 
 		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
 		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);

--- a/ChaosMod/Effects/db/Vehs/VehsColorController.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsColorController.cpp
@@ -6,6 +6,8 @@ static void OnTickRed()
 	{
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 255, 0, 0);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 255, 0, 0);
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 }
 
@@ -24,6 +26,8 @@ static void OnTickBlue()
 	{
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 0, 0, 255);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 0, 0, 255);
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 }
 
@@ -42,6 +46,8 @@ static void OnTickGreen()
 	{
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 0, 255, 0);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 0, 255, 0);
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 }
 
@@ -59,6 +65,8 @@ static void OnTickChrome()
 	for (Vehicle veh : GetAllVehs())
 	{
 		SET_VEHICLE_COLOURS(veh, 120, 120);
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 }
 
@@ -118,6 +126,8 @@ static void OnTickPink()
 
 		SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(veh, 255, 0, 255);
 		SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(veh, 255, 0, 255);
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 }
 
@@ -171,6 +181,9 @@ static void OnTickRainbow()
 
 		TOGGLE_VEHICLE_MOD(veh, 22, true);
 		_SET_VEHICLE_XENON_LIGHTS_COLOR(veh, headlightColor);
+
+		SET_VEHICLE_ENVEFF_SCALE(veh, 0.f);
+		SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
 	}
 
 	// Headlight color switcher


### PR DESCRIPTION
The enveff scale and dirt level are relatively minor changes, but makes all affected vehicles look more alike, which I think adds to the effect.

Tyre smoke color changes with vehicle color changing effects.

"Midas Touch" and "Chrome Traffic" would not work if the vehicle had a custom RGB color, clearing the custom color ensures that there won't be any mismatch if for example "Chrome Traffic" triggers right after "Red Traffic".