### PR TITLE
Changed to be able to accept from any IP for overlay

### DIFF
--- a/TwitchChatVotingProxy/OverlayServer/OverlayServer.cs
+++ b/TwitchChatVotingProxy/OverlayServer/OverlayServer.cs
@@ -19,7 +19,7 @@ namespace TwitchChatVotingProxy.OverlayServer
 
             try
             {
-                var WSS = new Fleck.WebSocketServer($"ws://127.0.0.1:{config.Port}");
+                var WSS = new Fleck.WebSocketServer($"ws://0.0.0.0:{config.Port}");
                 // Set the websocket listeners
                 WSS.Start(connection =>
                 {


### PR DESCRIPTION
Changed the Twitch Proxy Server so it can accept the overlay connection from any IP. This helps with a 2 PC stream setup and having all the overlays on the stream PC and none on the game PC. After this change the javascript file just needs to be changed to point to whatever IP address instead of the default of 127.0.0.1