### PR TITLE
Added 20 extra possible display names for "Nothing"

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscNothing.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNothing.cpp
@@ -1,6 +1,38 @@
 #include <stdafx.h>
+static std::string options[15] =
+{ "Nothing",
+"All Peds Are Peds",
+"Teleport To Current Location",
+"Expanded & Enhanced",
+"Spawn Air",
+"Destroy All Destroyed Vehicles",
+"Kill All Dead Peds",
+"+0 Wanted Stars",
+"Jesus Take No Wheel",
+"Set Time To Current Time",
+"Set Player Into Current Vehicle",
+"1x Vehicle Engine Speed",
+"You Aren't Famous",
+"GTA 5",
+"Crimes Are Illegal" };
 
-static RegisterEffect registerEffect(EFFECT_NOTHING, nullptr, nullptr, nullptr, EffectInfo
+
+static void OnStart()
+{
+
+	int start = GET_GAME_TIMER();
+	std::string override = options[g_Random.GetRandomInt(0, options->size() - 1)];
+	while (start + 25000 > GET_GAME_TIMER())
+	{
+		WAIT(0);
+		g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, override);
+
+
+
+
+	}
+}
+static RegisterEffect registerEffect(EFFECT_NOTHING, OnStart, EffectInfo
 	{
 		.Name = "Nothing",
 		.Id = "nothing"

--- a/ChaosMod/Effects/db/Misc/MiscNothing.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNothing.cpp
@@ -1,5 +1,5 @@
 #include <stdafx.h>
-static std::string options[15] =
+static std::string options[20] =
 { "Nothing",
 "All Peds Are Peds",
 "Teleport To Current Location",
@@ -8,13 +8,18 @@ static std::string options[15] =
 "Destroy All Destroyed Vehicles",
 "Kill All Dead Peds",
 "+0 Wanted Stars",
-"Jesus Take No Wheel",
+"Jesus Watches Over You",
 "Set Time To Current Time",
 "Set Player Into Current Vehicle",
-"1x Vehicle Engine Speed",
-"You Aren't Famous",
-"GTA 5",
-"Crimes Are Illegal" };
+"All Cops Are Cops",
+"Aim to Point Gun",
+"Give Everyone A Nose",
+"Teleport Player A Few Millimeters",
+"Flying Birds",
+"Teleport All Elephants To Player",
+"PC Experience",
+"All Enemies Attack Player",
+" "};
 
 
 static void OnStart()
@@ -26,9 +31,6 @@ static void OnStart()
 	{
 		WAIT(0);
 		g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, override);
-
-
-
 
 	}
 }

--- a/ChaosMod/Effects/db/Misc/MiscNothing.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNothing.cpp
@@ -24,13 +24,13 @@ static std::string options[20] =
 
 static void OnStart()
 {
-
+	
 	int start = GET_GAME_TIMER();
-	std::string override = options[g_Random.GetRandomInt(0, options->size() - 1)];
+	std::string effectOverride = options[g_Random.GetRandomInt(0, options->size() - 1)];
 	while (start + 25000 > GET_GAME_TIMER())
 	{
 		WAIT(0);
-		g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, override);
+		g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, effectOverride);
 
 	}
 }

--- a/ChaosMod/Effects/db/Misc/MiscNothing.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNothing.cpp
@@ -1,5 +1,5 @@
 #include <stdafx.h>
-static std::string options[20] =
+static std::array options =
 { "Nothing",
 "All Peds Are Peds",
 "Teleport To Current Location",
@@ -25,7 +25,7 @@ static std::string options[20] =
 static void OnStart()
 {
 	
-	std::string effectOverride = options[g_Random.GetRandomInt(0, options->size() - 1)];
+	std::string effectOverride = options[g_Random.GetRandomInt(0, options.size() - 1)];
 	WAIT(0);
 	g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, effectOverride);
 	WAIT(25000);

--- a/ChaosMod/Effects/db/Misc/MiscNothing.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNothing.cpp
@@ -25,14 +25,11 @@ static std::string options[20] =
 static void OnStart()
 {
 	
-	int start = GET_GAME_TIMER();
 	std::string effectOverride = options[g_Random.GetRandomInt(0, options->size() - 1)];
-	while (start + 25000 > GET_GAME_TIMER())
-	{
-		WAIT(0);
-		g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, effectOverride);
-
-	}
+	WAIT(0);
+	g_pEffectDispatcher->OverrideEffectName(EFFECT_NOTHING, effectOverride);
+	WAIT(25000);
+	
 }
 static RegisterEffect registerEffect(EFFECT_NOTHING, OnStart, EffectInfo
 	{


### PR DESCRIPTION
Added the following possible display names to "Nothing". The display name will change back to "Nothing" after 25 seconds. The effect will still be registered as "Nothing" and also show up like that in twitch voting.

"Nothing",
"All Peds Are Peds",
"Teleport To Current Location",
"Expanded & Enhanced",
"Spawn Air",
"Destroy All Destroyed Vehicles",
"Kill All Dead Peds",
"+0 Wanted Stars",
"Jesus Watches Over You",
"Set Time To Current Time",
"Set Player Into Current Vehicle",
"All Cops Are Cops",
"Aim to Point Gun",
"Give Everyone A Nose",
"Teleport Player A Few Millimeters",
"Flying Birds",
"Teleport All Elephants To Player",
"PC Experience",
"All Enemies Attack Player",
" " <- (actually nothing, will leave the player confused)