### PR TITLE
Crash Fix for Effects using GetAllPeds/Vehs/Props

### DIFF
--- a/ChaosMod/Effects/db/Vehs/VehsCrumble.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsCrumble.cpp
@@ -6,7 +6,7 @@
 
 static void OnTick()
 {
-	std::vector<Vehicle> vehs = GetAllVehs();
+	std::vector<Vehicle> vehs = GetAllVehsArray ();
 	int vehicleAmount = static_cast<int>(vehs.size());
 
 	if (vehicleAmount > 0)

--- a/ChaosMod/LuaScripts.cpp
+++ b/ChaosMod/LuaScripts.cpp
@@ -329,14 +329,14 @@ namespace LuaScripts
 					{ return LuaInvoke(szFileName, lua, ullHash, eReturnType, args); };
 				lua["WAIT"] = WAIT;
 
-				lua["GetAllPeds"] = GetAllPeds;
+				lua["GetAllPeds"] = GetAllPedsArray;
 				lua["CreatePoolPed"] = CreatePoolPed;
 
-				lua["GetAllVehicles"] = GetAllVehs;
+				lua["GetAllVehicles"] = GetAllVehsArray;
 				lua["CreatePoolVehicle"] = CreatePoolVehicle;
 				lua["CreateTempVehicle"] = CreateTempVehicle;
 
-				lua["GetAllProps"] = GetAllProps;
+				lua["GetAllProps"] = GetAllPropsArray;
 				lua["CreatePoolProp"] = CreatePoolProp;
 
 				lua["GetAllWeapons"] = Memory::GetAllWeapons;

--- a/ChaosMod/Util/EntityIterator.h
+++ b/ChaosMod/Util/EntityIterator.h
@@ -6,7 +6,81 @@
 
 // Thanks to menyoo for most of these!!
 
-class VehiclePool
+// Pool Interator class to iterate over pools. Has just enough operators defined to be able to be used in a for loop, not suitable for any other iterating.
+template<typename T>
+class PoolIterator
+{
+public:
+	T* Pool = nullptr;
+	int32_t Index = 0;
+
+	explicit PoolIterator (T *pool, int32_t index = 0)
+        {
+		this->Pool  = pool;
+		this->Index = index;
+        }
+
+	PoolIterator& operator++()
+	{
+		for (Index++; Index < Pool->m_ulSize; Index++)
+			{
+				if (Pool->IsValid (Index))
+					{
+						return *this;
+					}
+			}
+
+		Index = Pool->m_ulSize;
+		return *this;
+	}
+
+	Entity operator*()
+        {
+		static int(*_addEntityToPoolFunc)(__int64) = []
+		{
+			Handle handle = Memory::FindPattern("48 F7 F9 49 8B 48 08 48 63 D0 C1 E0 08 0F B6 1C 11 03 D8").Addr();
+			return handle.At(-0x68).Get<int(__int64)>();
+		}();
+
+		__int64 ullAddr = Pool->GetAddress(Index);
+		int iHandle = _addEntityToPoolFunc(ullAddr);
+		return iHandle;
+        }
+
+	bool operator!=(const PoolIterator &other) const
+        {
+		return this->Index != other.Index;
+        }
+};
+
+// Common functions for VehiclePool and GenericPool
+template<typename T>
+class PoolUtils
+{
+public:
+	inline auto ToArray ()
+	{
+		std::vector<Entity> arr;
+		for (auto entity : *static_cast<T*>(this))
+			{
+				arr.push_back (entity);
+			}
+
+		return arr;
+	}
+
+	auto begin ()
+	{
+		return ++PoolIterator<T> (static_cast<T*>(this), -1);
+	}
+
+	auto end ()
+	{
+		return ++PoolIterator<T> (static_cast<T*>(this), static_cast<T*>(this)->m_ulSize);
+	}
+};
+
+class VehiclePool : public PoolUtils<VehiclePool>
 {
 public:
 	UINT64* m_pullPoolAddress;
@@ -27,7 +101,7 @@ public:
 	}
 };
 
-class GenericPool
+class GenericPool : public PoolUtils<GenericPool>
 {
 public:
 	UINT64 m_ullPoolStartAddress;
@@ -54,174 +128,48 @@ private:
 };
 
 
-enum class EReturnedEntityType
+inline auto& GetAllPeds()
 {
-	Peds,
-	Vehs,
-	Props
-};
+	static GenericPool* pPedPool = [] {
+		Handle handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? 41 0F BF C8 0F BF 40 10");
+		return handle.At(2).Into().Value<GenericPool*>();
+	} ();
 
-inline std::vector<Entity> GetAllOfEntityType(EReturnedEntityType entityType)
-{
-	static GenericPool* pPedPool;
-	static VehiclePool* pVehPool;
-	static GenericPool* pPropPool;
-
-	static int(*_addEntityToPoolFunc)(__int64);
-
-	std::vector<Entity> rgEntities;
-
-	static bool c_bDidInit = false;
-	if (!c_bDidInit)
-	{
-		Handle handle;
-
-		handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? 41 0F BF C8 0F BF 40 10");
-		if (!handle.IsValid())
-		{
-			return rgEntities;
-		}
-
-		pPedPool = handle.At(2).Into().Value<GenericPool*>();
-
-		handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? F3 0F 59 F6 48 8B 08");
-		if (!handle.IsValid())
-		{
-			return rgEntities;
-		}
-
-		pVehPool = *handle.At(2).Into().Value<VehiclePool**>();
-
-		handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? 8B 78 10 85 FF");
-		if (!handle.IsValid())
-		{
-			return rgEntities;
-		}
-
-		pPropPool = handle.At(2).Into().Value<GenericPool*>();
-
-		handle = Memory::FindPattern("48 F7 F9 49 8B 48 08 48 63 D0 C1 E0 08 0F B6 1C 11 03 D8").Addr();
-		if (!handle.IsValid())
-		{
-			return rgEntities;
-		}
-
-		_addEntityToPoolFunc = handle.At(-0x68).Get<int(__int64)>();
-
-		c_bDidInit = true;
-	}
-
-	switch (entityType)
-	{
-	case EReturnedEntityType::Peds:
-		for (int i = 0; i < pPedPool->m_ulSize; i++)
-		{
-			if (pPedPool->IsValid(i))
-			{
-				__int64 ullAddr = pPedPool->GetAddress(i);
-
-				if (ullAddr)
-				{
-					int iHandle = _addEntityToPoolFunc(ullAddr);
-
-					if (DOES_ENTITY_EXIST(iHandle))
-					{
-						rgEntities.push_back(iHandle);
-					}
-				}
-			}
-		}
-
-		break;
-	case EReturnedEntityType::Vehs:
-		for (int i = 0; i < pVehPool->m_ulSize; i++)
-		{
-			if (pVehPool->IsValid(i))
-			{
-				__int64 ullAddr = pVehPool->GetAddress(i);
-
-				if (ullAddr)
-				{
-					int iHandle = _addEntityToPoolFunc(ullAddr);
-
-					if (DOES_ENTITY_EXIST(iHandle))
-					{
-						rgEntities.push_back(iHandle);
-					}
-				}
-			}
-		}
-
-		break;
-	case EReturnedEntityType::Props:
-		for (int i = 0; i < pPropPool->m_ulSize; i++)
-		{
-			if (pPropPool->IsValid(i))
-			{
-				__int64 ullAddr = pPropPool->GetAddress(i);
-
-				if (ullAddr)
-				{
-					int iHandle = _addEntityToPoolFunc(ullAddr);
-
-					if (DOES_ENTITY_EXIST(iHandle))
-					{
-						rgEntities.push_back(iHandle);
-					}
-				}
-			}
-		}
-
-		break;
-	}
-
-	return rgEntities;
+	return *pPedPool;
 }
 
-inline const std::vector<Ped>& GetAllPeds()
+inline auto& GetAllVehs()
 {
-	static std::vector<Ped> c_rgPeds;
+	static VehiclePool* pVehPool = [] {
+		Handle handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? F3 0F 59 F6 48 8B 08");
+		return *handle.At(2).Into().Value<VehiclePool**>();
+	} ();
 
-	static int c_ilastFrame = 0;
-	int iCurFrame = GET_FRAME_COUNT();
-	if (c_ilastFrame < iCurFrame)
-	{
-		c_ilastFrame = iCurFrame;
-
-		c_rgPeds = GetAllOfEntityType(EReturnedEntityType::Peds);
-	}
-
-	return c_rgPeds;
+	return *pVehPool;
 }
 
-inline const std::vector<Vehicle>& GetAllVehs()
+inline auto& GetAllProps()
 {
-	static std::vector<Vehicle> rgVehs;
+	static GenericPool* pPropPool = [] {
+		Handle handle = Memory::FindPattern("48 8B 05 ?? ?? ?? ?? 8B 78 10 85 FF");
+		return handle.At(2).Into().Value<GenericPool*>();
+	} ();
 
-	static int c_iLastFrame = 0;
-	int iCurFrame = GET_FRAME_COUNT();
-	if (c_iLastFrame < iCurFrame)
-	{
-		c_iLastFrame = iCurFrame;
-
-		rgVehs = GetAllOfEntityType(EReturnedEntityType::Vehs);
-	}
-
-	return rgVehs;
+	return *pPropPool;
 }
 
-inline const std::vector<Object>& GetAllProps()
+inline auto GetAllPedsArray()
 {
-	static std::vector<Object> rgProps;
-
-	static int iLastFrame = 0;
-	int iCurFrame = GET_FRAME_COUNT();
-	if (iLastFrame < iCurFrame)
-	{
-		iLastFrame = iCurFrame;
-
-		rgProps = GetAllOfEntityType(EReturnedEntityType::Props);
-	}
-
-	return rgProps;
+	return GetAllPeds().ToArray ();
 }
+
+inline auto GetAllVehsArray()
+{
+	return GetAllVehs().ToArray ();
+}
+
+inline auto GetAllPropsArray()
+{
+	return GetAllProps().ToArray ();
+}
+


### PR DESCRIPTION
* Fixes undefined behaviour of GetAllPeds/GetAllVehs/GetAllProps caused by thread-unsafe usage of these functions by certain effects.

* This commit changes the functions to use a more efficient and less error-prone function that will allow iterating directly over the pools instead of being copied multiple times in an array.

* In an effort to maintain compatibility with Lua scripts, helper functions "GetAll<Peds/Vehs/Props>Array" have been added that are aliased to "GetAll<Peds/Vehs/Props>" in Lua that return a copy of the list of valid entities at that frame.

* It does not have error checks for if the patterns fail to get a match since it's not trivial to replicate the previous behaviour of returning an empty set with these iterators.