### PR TITLE
Change Memory::FindPattern Implementation

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -323,6 +323,7 @@
     <ClCompile Include="Memory\Hooks\AudioPitchHook.cpp" />
     <ClCompile Include="Memory\Hooks\MiscHooks.cpp" />
     <ClCompile Include="Memory\Memory.cpp" />
+    <ClCompile Include="..\vendor\Patterns\Patterns.cpp" />
     <ClCompile Include="Components\SplashTexts.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/ChaosMod/Memory/Memory.cpp
+++ b/ChaosMod/Memory/Memory.cpp
@@ -80,55 +80,21 @@ namespace Memory
 
 	Handle FindPattern(const std::string& szPattern)
 	{
-		std::vector<short> rgBytes;
-
-		std::string szSub = szPattern;
-		int iOffset = 0;
-		while ((iOffset = szSub.find(' ')) != szSub.npos)
+		std::string szCopy = szPattern;
+		for (size_t pos = szCopy.find("??"); pos != std::string::npos; pos = szCopy.find("??", pos+1))
 		{
-			std::string byteStr = szSub.substr(0, iOffset);
-
-			if (byteStr == "?" || byteStr == "??")
-			{
-				rgBytes.push_back(-1);
-			}
-			else
-			{
-				rgBytes.push_back(std::stoi(byteStr, nullptr, 16));
-			}
-
-			szSub = szSub.substr(iOffset + 1);
+			szCopy.replace(pos, 2, "?");
 		}
-		if ((iOffset = szPattern.rfind(' ')) != szSub.npos)
+		
+		hook::pattern pattern(szCopy);
+		if (!pattern.size())
 		{
-			std::string szByteStr = szPattern.substr(iOffset + 1);
-			rgBytes.push_back(std::stoi(szByteStr, nullptr, 16));
-		}
-
-		if (rgBytes.empty())
-		{
+			LOG("Couldn't find pattern \"" << szPattern << "\"");
+			
 			return Handle();
 		}
 
-		int niCount = 0;
-		for (DWORD64 ullAddr = ms_ullBaseAddr; ullAddr < ms_ullEndAddr; ullAddr++)
-		{
-			if (rgBytes[niCount] == -1 || *reinterpret_cast<BYTE*>(ullAddr) == rgBytes[niCount])
-			{
-				if (++niCount == rgBytes.size())
-				{
-					return Handle(ullAddr - niCount + 1);
-				}
-			}
-			else
-			{
-				niCount = 0;
-			}
-		}
-
-		LOG("Couldn't find pattern \"" << szPattern << "\"");
-
-		return Handle();
+		return Handle(uintptr_t(pattern.get_first()));
 	}
 
 	_NODISCARD MH_STATUS AddHook(void* pTarget, void* pDetour, void* ppOrig)

--- a/ChaosMod/stdafx.h
+++ b/ChaosMod/stdafx.h
@@ -60,6 +60,7 @@
 #include "../vendor/scripthookv/inc/main.h"
 #include "../vendor/scripthookv/inc/natives.h"
 #include "../vendor/minhook/include/MinHook.h"
+#include "../vendor/Patterns/Patterns.h"
 #define SOL_ALL_SAFETIES_ON 1
 #define SOL_SAFE_NUMERICS 1
 #include "../vendor/sol3/sol.hpp"

--- a/vendor/Patterns/Patterns.cpp
+++ b/vendor/Patterns/Patterns.cpp
@@ -1,0 +1,277 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <stdafx.h>
+#include "Patterns.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <algorithm>
+
+#if PATTERNS_USE_HINTS
+#include <map>
+#endif
+
+
+#if PATTERNS_USE_HINTS
+
+// from boost someplace
+template <std::uint64_t FnvPrime, std::uint64_t OffsetBasis>
+struct basic_fnv_1
+{
+	std::uint64_t operator()(std::string_view text) const
+	{
+		std::uint64_t hash = OffsetBasis;
+		for (auto it : text)
+		{
+			hash *= FnvPrime;
+			hash ^= it;
+		}
+
+		return hash;
+	}
+};
+
+static constexpr std::uint64_t fnv_prime = 1099511628211u;
+static constexpr std::uint64_t fnv_offset_basis = 14695981039346656037u;
+
+typedef basic_fnv_1<fnv_prime, fnv_offset_basis> fnv_1;
+
+#endif
+
+namespace hook
+{
+	ptrdiff_t baseAddressDifference;
+
+	// sets the base to the process main base
+	void set_base()
+	{
+		set_base((uintptr_t)GetModuleHandle(nullptr));
+	}
+
+
+#if PATTERNS_USE_HINTS
+static auto& getHints()
+{
+	static std::multimap<uint64_t, uintptr_t> hints;
+	return hints;
+}
+#endif
+
+static void TransformPattern(std::string_view pattern, std::basic_string<uint8_t>& data, std::basic_string<uint8_t>& mask)
+{
+	uint8_t tempDigit = 0;
+	bool tempFlag = false;
+
+	auto tol = [] (char ch) -> uint8_t
+	{
+		if (ch >= 'A' && ch <= 'F') return uint8_t(ch - 'A' + 10);
+		if (ch >= 'a' && ch <= 'f') return uint8_t(ch - 'a' + 10);
+		return uint8_t(ch - '0');
+	};
+
+	for (auto ch : pattern)
+	{
+		if (ch == ' ')
+		{
+			continue;
+		}
+		else if (ch == '?')
+		{
+			data.push_back(0);
+			mask.push_back(0);
+		}
+		else if ((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f'))
+		{
+			uint8_t thisDigit = tol(ch);
+
+			if (!tempFlag)
+			{
+				tempDigit = thisDigit << 4;
+				tempFlag = true;
+			}
+			else
+			{
+				tempDigit |= thisDigit;
+				tempFlag = false;
+
+				data.push_back(tempDigit);
+				mask.push_back(0xFF);
+			}
+		}
+	}
+}
+
+class executable_meta
+{
+private:
+	uintptr_t m_begin;
+	uintptr_t m_end;
+
+public:
+	template<typename TReturn, typename TOffset>
+	TReturn* getRVA(TOffset rva)
+	{
+		return (TReturn*)(m_begin + rva);
+	}
+
+	explicit executable_meta(uintptr_t module)
+		: m_begin(module)
+	{
+		PIMAGE_DOS_HEADER dosHeader = getRVA<IMAGE_DOS_HEADER>(0);
+		PIMAGE_NT_HEADERS ntHeader = getRVA<IMAGE_NT_HEADERS>(dosHeader->e_lfanew);
+
+		m_end = m_begin + ntHeader->OptionalHeader.SizeOfImage;
+	}
+
+	executable_meta(uintptr_t begin, uintptr_t end)
+		: m_begin(begin), m_end(end)
+	{
+	}
+
+	inline uintptr_t begin() const { return m_begin; }
+	inline uintptr_t end() const   { return m_end; }
+};
+
+void pattern::Initialize(std::string_view pattern)
+{
+	// get the hash for the base pattern
+#if PATTERNS_USE_HINTS
+	m_hash = fnv_1()(pattern);
+#endif
+
+	// transform the base pattern from IDA format to canonical format
+	TransformPattern(pattern, m_bytes, m_mask);
+
+#if PATTERNS_USE_HINTS
+	// if there's hints, try those first
+#if PATTERNS_CAN_SERIALIZE_HINTS
+	if (m_rangeStart == reinterpret_cast<uintptr_t>(GetModuleHandle(nullptr)))
+#endif
+	{
+		auto range = getHints().equal_range(m_hash);
+
+		if (range.first != range.second)
+		{
+			std::for_each(range.first, range.second, [&] (const auto& hint)
+			{
+				ConsiderHint(hint.second);
+			});
+
+			// if the hints succeeded, we don't need to do anything more
+			if (!m_matches.empty())
+			{
+				m_matched = true;
+				return;
+			}
+		}
+	}
+#endif
+}
+
+void pattern::EnsureMatches(uint32_t maxCount)
+{
+	if (m_matched)
+	{
+		return;
+	}
+
+	// scan the executable for code
+	executable_meta executable = m_rangeStart != 0 && m_rangeEnd != 0 ? executable_meta(m_rangeStart, m_rangeEnd) : executable_meta(m_rangeStart);
+
+	auto matchSuccess = [&] (uintptr_t address)
+	{
+#if PATTERNS_USE_HINTS
+		getHints().emplace(m_hash, address);
+#else
+		(void)address;
+#endif
+
+		return (m_matches.size() == maxCount);
+	};
+
+	const uint8_t* pattern = m_bytes.data();
+	const uint8_t* mask = m_mask.data();
+	const size_t maskSize = m_mask.size();
+	const size_t lastWild = m_mask.find_last_not_of(uint8_t(0xFF));
+
+	ptrdiff_t Last[256];
+
+	std::fill(std::begin(Last), std::end(Last), lastWild == std::string::npos ? -1 : static_cast<ptrdiff_t>(lastWild) );
+
+	for ( ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(maskSize); ++i )
+	{
+		if ( Last[ pattern[i] ] < i )
+		{
+			Last[ pattern[i] ] = i;
+		}
+	}
+
+	for (uintptr_t i = executable.begin(), end = executable.end() - maskSize; i <= end;)
+	{
+		uint8_t* ptr = reinterpret_cast<uint8_t*>(i);
+		ptrdiff_t j = maskSize - 1;
+
+		while((j >= 0) && pattern[j] == (ptr[j] & mask[j])) j--;
+
+		if(j < 0)
+		{
+			m_matches.emplace_back(ptr);
+
+			if (matchSuccess(i))
+			{
+				break;
+			}
+			i++;
+		}
+		else i += max(ptrdiff_t(1), j - Last[ ptr[j] ]);
+	}
+
+	m_matched = true;
+}
+
+bool pattern::ConsiderHint(uintptr_t offset)
+{
+	uint8_t* ptr = reinterpret_cast<uint8_t*>(offset);
+
+#if PATTERNS_CAN_SERIALIZE_HINTS
+	const uint8_t* pattern = m_bytes.data();
+	const uint8_t* mask = m_mask.data();
+
+	for (size_t i = 0, j = m_mask.size(); i < j; i++)
+	{
+		if (pattern[i] != (ptr[i] & mask[i]))
+		{
+			return false;
+		}
+	}
+#endif
+
+	m_matches.emplace_back(ptr);
+
+	return true;
+}
+
+#if PATTERNS_USE_HINTS && PATTERNS_CAN_SERIALIZE_HINTS
+void pattern::hint(uint64_t hash, uintptr_t address)
+{
+	auto& hints = getHints();
+
+	auto range = hints.equal_range(hash);
+
+	for (auto it = range.first; it != range.second; ++it)
+	{
+		if (it->second == address)
+		{
+			return;
+		}
+	}
+
+	hints.emplace(hash, address);
+}
+#endif
+}

--- a/vendor/Patterns/Patterns.h
+++ b/vendor/Patterns/Patterns.h
@@ -1,0 +1,203 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <vector>
+#include <string>
+#include <string_view>
+
+namespace hook
+{
+	extern ptrdiff_t baseAddressDifference;
+
+	// sets the base address difference based on an obtained pointer
+	inline void set_base(uintptr_t address)
+	{
+#ifdef _M_IX86
+		uintptr_t addressDiff = (address - 0x400000);
+#elif defined(_M_AMD64)
+		uintptr_t addressDiff = (address - 0x140000000);
+#endif
+
+		// pointer-style cast to ensure unsigned overflow ends up copied directly into a signed value
+		baseAddressDifference = *(ptrdiff_t*)&addressDiff;
+	}
+
+	// sets the base to the process main base
+	void set_base();
+
+	inline uintptr_t getRVA(uintptr_t rva)
+	{
+		set_base();
+#ifdef _M_IX86
+		return static_cast<uintptr_t>(baseAddressDifference + 0x400000 + rva);
+#elif defined(_M_AMD64)
+		return static_cast<uintptr_t>(baseAddressDifference + 0x140000000 + rva);
+#endif
+	}
+
+	class pattern_match
+	{
+	private:
+		void* m_pointer;
+
+	public:
+		inline pattern_match(void* pointer)
+			: m_pointer(pointer)
+		{
+		}
+
+		template<typename T>
+		T* get(ptrdiff_t offset = 0) const
+		{
+			char* ptr = reinterpret_cast<char*>(m_pointer);
+			return reinterpret_cast<T*>(ptr + offset);
+		}
+	};
+
+	class pattern
+	{
+	private:
+		std::basic_string<uint8_t> m_bytes;
+		std::basic_string<uint8_t> m_mask;
+
+#if PATTERNS_USE_HINTS
+		uint64_t m_hash;
+#endif
+
+		std::vector<pattern_match> m_matches;
+
+		bool m_matched = false;
+
+		uintptr_t m_rangeStart;
+		uintptr_t m_rangeEnd;
+
+	private:
+		void Initialize(std::string_view pattern);
+
+		bool ConsiderHint(uintptr_t offset);
+
+		void EnsureMatches(uint32_t maxCount);
+
+		inline pattern_match _get_internal(size_t index) const
+		{
+			return m_matches[index];
+		}
+
+		inline pattern(uintptr_t module)
+			: pattern( module, 0 )
+		{
+		}
+
+		inline pattern(uintptr_t begin, uintptr_t end)
+			: m_rangeStart(begin), m_rangeEnd(end)
+		{
+		}
+
+	public:
+		pattern(std::string_view pattern)
+			: hook::pattern(getRVA(0))
+		{
+			Initialize(std::move(pattern));
+		}
+
+		inline pattern(void* module, std::string_view pattern)
+			: hook::pattern(reinterpret_cast<uintptr_t>(module))
+		{
+			Initialize(std::move(pattern));
+		}
+
+		inline pattern(uintptr_t begin, uintptr_t end, std::string_view pattern)
+			: m_rangeStart(begin), m_rangeEnd(end)
+		{
+			Initialize(std::move(pattern));
+		}
+
+		inline pattern&& count(uint32_t expected)
+		{
+			EnsureMatches(expected);
+			assert(m_matches.size() == expected);
+			return std::forward<pattern>(*this);
+		}
+
+		inline pattern&& count_hint(uint32_t expected)
+		{
+			EnsureMatches(expected);
+			return std::forward<pattern>(*this);
+		}
+
+		inline pattern&& clear()
+		{
+			m_matches.clear();
+			m_matched = false;
+			return std::forward<pattern>(*this);
+		}
+
+		inline size_t size()
+		{
+			EnsureMatches(UINT32_MAX);
+			return m_matches.size();
+		}
+
+		inline bool empty()
+		{
+			return size() == 0;
+		}
+
+		inline pattern_match get(size_t index)
+		{
+			EnsureMatches(UINT32_MAX);
+			return _get_internal(index);
+		}
+
+		inline pattern_match get_one()
+		{
+			return std::forward<pattern>(*this).count(1)._get_internal(0);
+		}
+
+		template<typename T = void>
+		inline auto get_first(ptrdiff_t offset = 0)
+		{
+			return get_one().get<T>(offset);
+		}
+
+		template <typename Pred>
+		inline Pred for_each_result(Pred&& pred)
+		{
+			EnsureMatches(UINT32_MAX);
+			for ( auto it : m_matches )
+			{
+				std::forward<Pred>(pred)(it);
+			}
+			return std::forward<Pred>(pred);
+		}
+
+	public:
+#if PATTERNS_USE_HINTS && PATTERNS_CAN_SERIALIZE_HINTS
+		// define a hint
+		static void hint(uint64_t hash, uintptr_t address);
+#endif
+	};
+
+	inline pattern make_module_pattern(void* module, std::string_view bytes)
+	{
+		return pattern(module, std::move(bytes));
+	}
+
+	inline pattern make_range_pattern(uintptr_t begin, uintptr_t end, std::string_view bytes)
+	{
+		return pattern(begin, end, std::move(bytes));
+	}
+
+	template<typename T = void>
+	inline auto get_pattern(std::string_view pattern_string, ptrdiff_t offset = 0)
+	{
+		return pattern(std::move(pattern_string)).get_first<T>(offset);
+	}
+}


### PR DESCRIPTION
There are certain issues with the FindPattern implementation currently used in the Chaos Mod code-base that this pull request aims to resolve:

* FindPattern doesn't support patterns ending with trailing "?", and will cause a crash if they're used.
* Memory::Init needs to be called before FindPattern or the function will not return a result
* The implementation used fails to match certain patterns in the executable.

The pull-request changes the implementation used to one from CFX in effort to fix these issues and also to allow additional pattern related functions to be added (one used by DLC Despawn fix for example).