### PR TITLE
Crash fixes for APPLY_FORCE_* natives

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -357,6 +357,7 @@
     <ClInclude Include="LuaScripts.h" />
     <ClInclude Include="Main.h" />
     <ClInclude Include="Memory\Gravity.h" />
+    <ClInclude Include="Memory\Physics.h" />
     <ClInclude Include="Memory\Handle.h" />
     <ClInclude Include="Memory\Hooks\ScriptThreadRunHook.h" />
     <ClInclude Include="Memory\Hooks\HandleToEntityStructHook.h" />

--- a/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
@@ -37,7 +37,7 @@ static void OnTick()
 
 	for (Entity entity : entities)
 	{
-		APPLY_FORCE_TO_ENTITY(entity, 1, 0, 0, shook, .0f, .0f, .0f, 0, true, true, true, false, true);
+		Memory::ApplyForceToEntity(entity, 1, 0, 0, shook, .0f, .0f, .0f, 0, true, true, true, false, true);
 	}
 }
 

--- a/ChaosMod/Effects/db/Misc/MiscGravityController.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscGravityController.cpp
@@ -43,13 +43,13 @@ static void OnTickInsane()
 		{
 			SET_PED_TO_RAGDOLL(ped, 1000, 1000, 0, true, true, false);
 
-			APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(ped, 0, 0, 0, -75.f, false, false, true, false);
+			Memory::ApplyForceToEntityCenterOfMass(ped, 0, 0, 0, -75.f, false, false, true, false);
 		}
 	}
 
 	for (auto object : GetAllProps())
 	{
-		APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(object, 0, 0, 0, -200.f, false, false, true, false);
+		Memory::ApplyForceToEntityCenterOfMass(object, 0, 0, 0, -200.f, false, false, true, false);
 	}
 }
 
@@ -77,13 +77,13 @@ static void OnTickInvert()
 		{
 			SET_PED_TO_RAGDOLL(ped, 1000, 1000, 0, true, true, false);
 
-			APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(ped, 0, 0, 0, 25.f, false, false, true, false);
+			Memory::ApplyForceToEntityCenterOfMass(ped, 0, 0, 0, 25.f, false, false, true, false);
 		}
 	}
 
 	for (auto object : GetAllProps())
 	{
-		APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(object, 0, 0, 0, 100.f, false, false, true, false);
+		Memory::ApplyForceToEntityCenterOfMass(object, 0, 0, 0, 100.f, false, false, true, false);
 	}
 }
 

--- a/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscMeteorRain.cpp
@@ -42,7 +42,7 @@ static void OnTick()
 		}
 
 		SET_OBJECT_PHYSICS_PARAMS(meteor, 100000.f, 1.f, 1.f, 0.f, 0.f, .5f, 0.f, 0.f, 0.f, 0.f, 0.f);
-		APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(meteor, 0, 50.f, 0, -10000.f, true, false, true, true);
+		Memory::ApplyForceToEntityCenterOfMass(meteor, 0, 50.f, 0, -10000.f, true, false, true, true);
 
 		SET_MODEL_AS_NO_LONGER_NEEDED(choosenPropHash);
 	}

--- a/ChaosMod/Effects/db/Misc/MiscRampJam.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscRampJam.cpp
@@ -11,7 +11,7 @@ static void OnTick()
 		Vehicle veh = GET_VEHICLE_PED_IS_IN(player, false);
 		if (IS_CONTROL_JUST_PRESSED(0, 22) && IS_VEHICLE_ON_ALL_WHEELS(veh))
 		{
-			APPLY_FORCE_TO_ENTITY(veh, 0, .0f, 850.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
+			Memory::ApplyForceToEntity(veh, 0, .0f, 850.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
 
 			Hash rampHash = GET_HASH_KEY("prop_mp_ramp_02");
 			Vector3 playerPos = GET_ENTITY_COORDS(player, false);

--- a/ChaosMod/Effects/db/Misc/MiscStuffGuns.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscStuffGuns.cpp
@@ -101,7 +101,7 @@ static void OnTick()
 						//prevent non-moveable objects cluttering up important areas
 						SET_OBJECT_AS_NO_LONGER_NEEDED(&thing);
 					}
-					APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(thing, 1, .0f, 1000.f, 0.f, false, true, true, false);
+					Memory::ApplyForceToEntityCenterOfMass(thing, 1, .0f, 1000.f, 0.f, false, true, true, false);
 				}
 			}
 		}

--- a/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
@@ -25,13 +25,13 @@ static void OnTick()
 	{
 		if (veh != playerVeh)
 		{
-			APPLY_FORCE_TO_ENTITY(veh, 3, 10.f, .1f, .1f, 0, 0, 0, 0, true, true, true, false, true);
+			Memory::ApplyForceToEntity(veh, 3, 10.f, .1f, .1f, 0, 0, 0, 0, true, true, true, false, true);
 		}
 	}
 
 	for (Object prop : GetAllProps())
 	{
-		APPLY_FORCE_TO_ENTITY(prop, 3, 10.f, 5.f, .1f, 0, 0, 0, 0, true, true, true, false, true);
+		Memory::ApplyForceToEntity(prop, 3, 10.f, 5.f, .1f, 0, 0, 0, 0, true, true, true, false, true);
 	}
 
 	DWORD64 curTick = GET_GAME_TIMER();

--- a/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscWhaleRain.cpp
@@ -43,7 +43,7 @@ static void OnTick()
 		SET_PED_TO_RAGDOLL(whale, 10000, 10000, 0, true, true, false);
 		SET_ENTITY_HEALTH(whale, 0, 0);
 
-		APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(whale, 0, 35.f, 0, -5000.f, true, false, true, true);
+		Memory::ApplyForceToEntityCenterOfMass(whale, 0, 35.f, 0, -5000.f, true, false, true, true);
 
 		SET_MODEL_AS_NO_LONGER_NEEDED(WHALE_MODEL);
 	}

--- a/ChaosMod/Effects/db/Peds/PedsCatGuns.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsCatGuns.cpp
@@ -48,7 +48,7 @@ static void OnTick()
 
 				SET_PED_TO_RAGDOLL(cat, 3000, 3000, 0, true, true, false);
 
-				APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(cat, 1, .0f, 300.f, 0.f, false, true, true, false);
+				Memory::ApplyForceToEntityCenterOfMass(cat, 1, .0f, 300.f, 0.f, false, true, true, false);
 
 				SET_PED_AS_NO_LONGER_NEEDED(&cat);
 			}

--- a/ChaosMod/Effects/db/Player/PlayerFlingPlayer.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFlingPlayer.cpp
@@ -22,7 +22,7 @@ static void OnStart()
 		entityToFlip = player;
 		SET_PED_TO_RAGDOLL(player, 5000, 0, 0, true, true, false);
 	}
-	APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(entityToFlip, 1, GetRandomForce(true), GetRandomForce(true), GetRandomForce(false), false, false, true, false);
+	Memory::ApplyForceToEntityCenterOfMass(entityToFlip, 1, GetRandomForce(true), GetRandomForce(true), GetRandomForce(false), false, false, true, false);
 }
 
 static RegisterEffect registerEffect(EFFECT_PLAYER_FLING_PLAYER, OnStart, nullptr, nullptr, EffectInfo

--- a/ChaosMod/Effects/db/Player/PlayerForcefield.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerForcefield.cpp
@@ -45,7 +45,7 @@ static void OnTick()
 			}
 			float forceDistance = min(max(0.f, (startDistance - distance)), maxForceDistance);
 			float force = (forceDistance / maxForceDistance) * maxForce;
-			APPLY_FORCE_TO_ENTITY(entity, 3, entityCoord.x - playerCoord.x, entityCoord.y - playerCoord.y, entityCoord.z - playerCoord.z, 0, 0, 0, false, false, true, true, false, true);
+			Memory::ApplyForceToEntity(entity, 3, entityCoord.x - playerCoord.x, entityCoord.y - playerCoord.y, entityCoord.z - playerCoord.z, 0, 0, 0, false, false, true, true, false, true);
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Player/PlayerHasGravity.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerHasGravity.cpp
@@ -53,7 +53,7 @@ static void OnTick()
 			}
 			float forceDistance = min(max(0.f, (startDistance - distance)), maxForceDistance);
 			float force = (forceDistance / maxForceDistance) * maxForce;
-			APPLY_FORCE_TO_ENTITY(entity, 3, (entityCoord.x - playerCoord.x) * -1.f, (entityCoord.y - playerCoord.y) * -1.f, (entityCoord.z - playerCoord.z) * -1.f, 0, 0, 0, false, false, true, true, false, true);
+			Memory::ApplyForceToEntity(entity, 3, (entityCoord.x - playerCoord.x) * -1.f, (entityCoord.y - playerCoord.y) * -1.f, (entityCoord.z - playerCoord.z) * -1.f, 0, 0, 0, false, false, true, true, false, true);
 		
 			if (IS_ENTITY_A_MISSION_ENTITY(entity))
 			{

--- a/ChaosMod/Effects/db/Player/PlayerJumpJump.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerJumpJump.cpp
@@ -15,7 +15,7 @@ static void OnTick()
 			Vehicle veh = GET_VEHICLE_PED_IS_IN(player, false);
 			if (!IS_ENTITY_IN_AIR(veh))
 			{
-				APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(veh, 0, .0f, .0f, 200.f, true, false, true, true);
+				Memory::ApplyForceToEntityCenterOfMass(veh, 0, .0f, .0f, 200.f, true, false, true, true);
 				lastCheck = GET_GAME_TIMER();
 			}
 		} 

--- a/ChaosMod/Effects/db/Player/PlayerKickflip.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerKickflip.cpp
@@ -17,7 +17,7 @@ static void OnStart()
 		entityToFlip = player;
 		SET_PED_TO_RAGDOLL(player, 200, 0, 0, true, true, false);
 	}
-	APPLY_FORCE_TO_ENTITY(entityToFlip, 1, 0, 0, 10, 2, 0, 0, 0, true, true, true, false, true);
+	Memory::ApplyForceToEntity(entityToFlip, 1, 0, 0, 10, 2, 0, 0, 0, true, true, true, false, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_PLAYER_KICKFLIP, OnStart, EffectInfo

--- a/ChaosMod/Effects/db/Vehs/VehsBeyblade.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsBeyblade.cpp
@@ -25,8 +25,8 @@ static void OnTick()
 
 		if (doBeyblade)
 		{
-			APPLY_FORCE_TO_ENTITY(veh, 3, force, 0, 0, 0, 4, 0, 0, true, true, true, true, true);
-			APPLY_FORCE_TO_ENTITY(veh, 3, -force, 0, 0, 0, -4, 0, 0, true, true, true, true, true);
+			Memory::ApplyForceToEntity(veh, 3, force, 0, 0, 0, 4, 0, 0, true, true, true, true, true);
+			Memory::ApplyForceToEntity(veh, 3, -force, 0, 0, 0, -4, 0, 0, true, true, true, true, true);
 			SET_ENTITY_INVINCIBLE(veh, true);
 			SET_VEHICLE_REDUCE_GRIP(veh, true);
 			if (GET_ENTITY_SPEED(veh) < 10)

--- a/ChaosMod/Effects/db/Vehs/VehsBouncy.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsBouncy.cpp
@@ -22,7 +22,7 @@ static void OnTick()
 			{
 				velFactor = 60.f;
 			}
-			APPLY_FORCE_TO_ENTITY(veh, 0, vel.x * -velFactor, vel.y * -velFactor, vel.z * -velFactor, .0f, .0f, .0f, 0, true, true, true, false, true);
+			Memory::ApplyForceToEntity(veh, 0, vel.x * -velFactor, vel.y * -velFactor, vel.z * -velFactor, .0f, .0f, .0f, 0, true, true, true, false, true);
 			
 		}
 	}

--- a/ChaosMod/Effects/db/Vehs/VehsBrakeBoosting.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsBrakeBoosting.cpp
@@ -13,7 +13,7 @@ static void OnTick()
 		// Also manually exclude blimps since those don't seem to be categorized as either of those
 		if (vehClass != 15 && vehModel != blimpHash && Memory::IsVehicleBraking(veh))
 		{
-			APPLY_FORCE_TO_ENTITY(veh, 0, .0f, 50.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
+			Memory::ApplyForceToEntity(veh, 0, .0f, 50.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Vehs/VehsHonkBoosting.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsHonkBoosting.cpp
@@ -6,7 +6,7 @@ static void OnTick()
 	{
 		if (IS_HORN_ACTIVE(veh))
 		{
-			APPLY_FORCE_TO_ENTITY(veh, 0, .0f, 50.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
+			Memory::ApplyForceToEntity(veh, 0, .0f, 50.f, .0f, .0f, .0f, .0f, 0, true, true, true, false, true);
 		}
 	}
 }

--- a/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsJumpy.cpp
@@ -14,7 +14,7 @@ static void OnTick()
 		{
 			if (veh != playerVeh && !IS_ENTITY_IN_AIR(veh))
 			{
-				APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(veh, 0, .0f, .0f, 500.f, true, false, true, true);
+				Memory::ApplyForceToEntityCenterOfMass(veh, 0, .0f, .0f, 500.f, true, false, true, true);
 			}
 		}
 	}

--- a/ChaosMod/Memory/Physics.h
+++ b/ChaosMod/Memory/Physics.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "Memory.h"
+#include "Handle.h"
+
+namespace Memory
+{
+	inline bool DoesEntityHaveCollider(Entity entity)
+	{
+
+		static auto CEntity_GetColliderNonConst = []() -> void* (*)(BYTE*)
+		{
+			Handle handle = FindPattern("? 85 C0 74 ? ? 3B ? ? ? ? ? 75 ? ? 8B CF E8 ? ? ? ? ? 8D");
+			if (handle.IsValid())
+			{
+				return handle.At(17).Into().Get<void*(BYTE*)>();
+			}
+
+			return nullptr;
+		}();
+
+		return CEntity_GetColliderNonConst(getScriptHandleBaseAddress (entity));
+	}
+
+	inline int GetNumFreeColliderSlots()
+	{
+		static auto phSimulator_sm_Instance = []
+		{
+			Handle handle = FindPattern("? 8B 0D ? ? ? ? ? 83 64 ? ? 00 ? 0F B7 D1 ? 33 C9 E8");
+			if (handle.IsValid())
+			{
+				return handle.At(2).Into().Addr();
+			}
+
+			return 0ull;
+		}();
+
+		static auto [usedCollidersOffset, maxCollidersOffset] = []
+		{
+			Handle handle = FindPattern("? 63 ? ? ? ? ? 3B ? ? ? ? ? 0F 8D ? ? ? ? ? 8B C8");
+			if (handle.IsValid())
+				return std::make_tuple(handle.At(3).Value<int>(), handle.At(9).Value<int>());
+			
+			return std::make_tuple(0x864, 0x860); // values in the latest version of the game.
+		}();
+
+		if (!phSimulator_sm_Instance)
+			return 100;
+
+		Handle handle(phSimulator_sm_Instance);
+		handle = handle.Value<DWORD64>();
+
+		if (handle.Addr() == 0)
+			return 0;
+
+		return (handle.At(maxCollidersOffset).Value<int>() - handle.At(usedCollidersOffset).Value<int>());
+	}
+
+	inline bool IsFreeToActivatePhysics()
+	{
+		const int MIN_FREE_COLLIDER_SLOTS = 50;
+		
+		return GetNumFreeColliderSlots() > MIN_FREE_COLLIDER_SLOTS;
+	}
+	
+	// Safe version of APPLY_FORCE_TO_ENTITY with checks for available colliders to ensure the physics engine is not overwhelmed.
+	inline void ApplyForceToEntity(Entity entity, int forceFlags, float x, float y, float z, float offX, float offY, float offZ, int boneIndex, BOOL isDirectionRel, BOOL ignoreUpVec, BOOL isForceRel, BOOL p12, BOOL p13)
+	{
+		if (IsFreeToActivatePhysics() || DoesEntityHaveCollider(entity))
+			APPLY_FORCE_TO_ENTITY(entity, forceFlags, x, y, z, offX, offY, offZ, boneIndex, isDirectionRel, ignoreUpVec, isForceRel, p12, p13);
+	}
+
+	// Safe version of APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS with checks for available colliders to ensure the physics engine is not overwhelmed.
+	inline void ApplyForceToEntityCenterOfMass(Entity entity, int forceType, float x, float y, float z, BOOL p5, BOOL isDirectionRel, BOOL isForceRel, BOOL p8)
+	{
+		if (IsFreeToActivatePhysics() || DoesEntityHaveCollider(entity))
+			APPLY_FORCE_TO_ENTITY_CENTER_OF_MASS(entity, forceType, x, y, z, p5, isDirectionRel, isForceRel, p8);
+	}
+}

--- a/ChaosMod/stdafx.h
+++ b/ChaosMod/stdafx.h
@@ -32,6 +32,7 @@
 #include "Memory/WeaponPool.h"
 #include "Memory/PedModels.h"
 #include "Memory/Misc.h"
+#include "Memory/Physics.h"
 
 #include "Memory/Hooks/Hook.h"
 


### PR DESCRIPTION
* Effects like Gravity Field and Doomsday tend to crash the game because of the physics engine's 228 (default) collider limit. Once the limit is reached, the game can no longer spawn any new dynamic entities and will crash as a result. 
* The PR adds a function with checks for these natives to ensure that enough colliders are available for the rest of the game.

Note: Requires #2644 to be merged because patterns used in the checks fail to match with the current FindPattern implementation.