### PR TITLE
Fixes a softlock with the mainthread-hook

### DIFF
--- a/ChaosMod/Main.cpp
+++ b/ChaosMod/Main.cpp
@@ -1,6 +1,7 @@
 #include <stdafx.h>
 
 #include "Main.h"
+#include "Memory/Hooks/ScriptThreadRunHook.h"
 
 static std::unique_ptr<DebugMenu> ms_pDebugMenu;
 static std::unique_ptr<TwitchVoting> ms_pTwitchVoting;
@@ -228,7 +229,7 @@ static void MainRun()
 		else if (IS_SCREEN_FADED_OUT())
 		{
 			SET_TIME_SCALE(1.f); // Prevent potential softlock for certain effects
-
+			Hooks::DisableScriptThreadBlock();
 			WAIT(100);
 
 			continue;

--- a/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
+++ b/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
@@ -8,11 +8,8 @@ __int64 HK_rage__scrThread__Run(rage::scrThread* pThread)
 	if (ms_bEnabledHook)
 	{
 		const char* szScriptName = pThread->m_szName;
-
-		// Scripthook (most likely) relies on these to run our script thread
-		// We don't want to block ourselves of course :p
-		if (strcmp(szScriptName, "main") && strcmp(szScriptName, "main_persistent") && strcmp(szScriptName, "control_thread"))
-		{
+		// Just block the mission watcher, which is enough to not fail the current mission
+		if (strcmp(szScriptName, "mission_stat_watcher")) {
 			return 0;
 		}
 	}

--- a/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
+++ b/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
@@ -8,8 +8,10 @@ __int64 HK_rage__scrThread__Run(rage::scrThread* pThread)
 	if (ms_bEnabledHook)
 	{
 		const char* szScriptName = pThread->m_szName;
-		// Just block the mission watcher, which is enough to not fail the current mission
-		if (strcmp(szScriptName, "mission_stat_watcher")) {
+		// Scripthook (most likely) relies on these to run our script thread
+		// We don't want to block ourselves of course :p
+		if (strcmp(szScriptName, "main") && strcmp(szScriptName, "main_persistent") && strcmp(szScriptName, "control_thread"))
+		{
 			return 0;
 		}
 	}


### PR DESCRIPTION
Fixes a softlock if you activate an effect, that blocks the mainthread on death. This would result in the game not continuing / showing you restart/exit on missions.
-> only block the "mission_stat_watcher"-thread, to block any mission fails for distance / car destroyed
-> Disable the block if the screen is faded out