### PR TITLE
Avoiding Teleporting Issues when in Aircraft

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerTpController.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerTpController.cpp
@@ -204,15 +204,7 @@ static void OnStartRandom()
 		}
 	}
 
-	// 15 is Helicopters and 16 is Planes
-	if (vehicleType == 15 || vehicleType == 16)
-	{
-		TeleportPlayer(x, y, useGroundZ ? groundZ : z + 100);
-	}
-	else
-	{
-		TeleportPlayer(x, y, useGroundZ ? groundZ : z);
-	}
+	TeleportPlayer(x, y, useGroundZ ? groundZ : z);
 }
 
 static RegisterEffect registerEffect8(EFFECT_TP_RANDOM, OnStartRandom, EffectInfo

--- a/ChaosMod/Effects/db/Player/PlayerTpController.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerTpController.cpp
@@ -172,9 +172,7 @@ static RegisterEffect registerEffect7(EFFECT_TP_FRONT, OnStartFront, EffectInfo
 static void OnStartRandom()
 {
 	Ped playerPed = PLAYER_PED_ID();
-	Vehicle playerVeh = GET_VEHICLE_PED_IS_IN(playerPed, false);
 	Vector3 playerPos = GET_ENTITY_COORDS(playerPed, false);
-	int vehicleType = GET_VEHICLE_CLASS(playerVeh);
 
 	float x, y, z = playerPos.z, _;
 	do

--- a/ChaosMod/Effects/db/Player/PlayerTpController.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerTpController.cpp
@@ -172,7 +172,9 @@ static RegisterEffect registerEffect7(EFFECT_TP_FRONT, OnStartFront, EffectInfo
 static void OnStartRandom()
 {
 	Ped playerPed = PLAYER_PED_ID();
+	Vehicle playerVeh = GET_VEHICLE_PED_IS_IN(playerPed, false);
 	Vector3 playerPos = GET_ENTITY_COORDS(playerPed, false);
+	int vehicleType = GET_VEHICLE_CLASS(playerVeh);
 
 	float x, y, z = playerPos.z, _;
 	do
@@ -202,7 +204,15 @@ static void OnStartRandom()
 		}
 	}
 
-	TeleportPlayer(x, y, useGroundZ ? groundZ : z);
+	// 15 is Helicopters and 16 is Planes
+	if (vehicleType == 15 || vehicleType == 16)
+	{
+		TeleportPlayer(x, y, useGroundZ ? groundZ : z + 100);
+	}
+	else
+	{
+		TeleportPlayer(x, y, useGroundZ ? groundZ : z);
+	}
 }
 
 static RegisterEffect registerEffect8(EFFECT_TP_RANDOM, OnStartRandom, EffectInfo

--- a/ChaosMod/Util/Player.h
+++ b/ChaosMod/Util/Player.h
@@ -8,11 +8,15 @@ inline void TeleportPlayer(float fPosX, float fPosY, float fPosZ, bool bNoOffset
 
 	bool isInVeh = IS_PED_IN_ANY_VEHICLE(playerPed, false);
 
+	bool isInFlyingVeh = IS_PED_IN_FLYING_VEHICLE(playerPed);
+
 	Vehicle playerVeh = GET_VEHICLE_PED_IS_IN(playerPed, false);
 
 	Vector3 vel = GET_ENTITY_VELOCITY(isInVeh ? playerVeh : playerPed);
 
 	float heading = GET_ENTITY_HEADING(isInVeh ? playerVeh : playerPed);
+
+	float groundHeight = GET_ENTITY_HEIGHT_ABOVE_GROUND(playerVeh);
 
 	float forwardSpeed;
 	if (isInVeh)
@@ -22,11 +26,11 @@ inline void TeleportPlayer(float fPosX, float fPosY, float fPosZ, bool bNoOffset
 
 	if (bNoOffset)
 	{
-		SET_ENTITY_COORDS_NO_OFFSET(isInVeh ? playerVeh : playerPed, fPosX, fPosY, fPosZ, false, false, false);
+		SET_ENTITY_COORDS_NO_OFFSET(isInVeh ? playerVeh : playerPed, fPosX, fPosY, isInFlyingVeh ? fPosZ + groundHeight : fPosZ, false, false, false);
 	}
 	else
 	{
-		SET_ENTITY_COORDS(isInVeh ? playerVeh : playerPed, fPosX, fPosY, fPosZ, false, false, false, false);
+		SET_ENTITY_COORDS(isInVeh ? playerVeh : playerPed, fPosX, fPosY, isInFlyingVeh ? fPosZ + groundHeight : fPosZ, false, false, false, false);
 	}
 
 	SET_ENTITY_HEADING(isInVeh ? playerVeh : playerPed, heading);


### PR DESCRIPTION
Addresses pull request #2661 where if you are in a airplane or helicopter teleporting to a random location can cause the aircraft to get stuck and explode. This is a super crude fix and could be implemented into the TeleportPlayer function to handle it for all teleports.