### PR TITLE
Fake TP Improvements

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerTpController.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerTpController.cpp
@@ -266,17 +266,16 @@ static RegisterEffect registerEffectMission(EFFECT_TP_MISSION, OnStartMission, E
 static struct FakeTeleportInfo
 {
 	EEffectType type;
-	Vector3 playerPos;
-	Vector3 vehiclePos;
+	void (*func)(void);
 };
 
 static const std::vector<FakeTeleportInfo> tpLocations =
 {
-	{EFFECT_TP_LSAIRPORT, {-1388.6f, -3111.61f, 13.94f}}, // LSIA
-	{EFFECT_TP_MAZETOWER, {-75.7f, -818.62f, 326.16f}}, // Maze Tower
-	{EFFECT_TP_FORTZANCUDO, {-2360.3f, 3244.83f, 92.9f}, {-2267.89f, 3121.04f, 32.5f}}, // Fort Zancudo
-	{EFFECT_TP_MOUNTCHILLIAD, {501.77f, 5604.85f, 797.91f}, {503.33f, 5531.91f, 777.45f}}, // Mount Chilliad
-	{EFFECT_TP_SKYFALL, {935.f, 3800.f, 2300.f}} // Heaven
+	{EFFECT_TP_LSAIRPORT, OnStartLSIA}, // LSIA
+	{EFFECT_TP_MAZETOWER, OnStartMazeTower}, // Maze Tower
+	{EFFECT_TP_FORTZANCUDO, OnStartFortZancudo}, // Fort Zancudo
+	{EFFECT_TP_MOUNTCHILLIAD, OnStartMountChilliad}, // Mount Chilliad
+	{EFFECT_TP_SKYFALL, OnStartSkyFall} // Heaven
 };
 
 static void OnStartFakeTp()
@@ -294,20 +293,13 @@ static void OnStartFakeTp()
 	Hooks::EnableScriptThreadBlock();
 
 	SET_ENTITY_INVINCIBLE(playerPed, true);
-	Vector3 destinationPos = selectedLocationInfo.playerPos;
-	if (playerVeh)
-	{
-		if (!selectedLocationInfo.vehiclePos.IsDefault()) {
-			destinationPos = selectedLocationInfo.vehiclePos;
-		}
-		SET_ENTITY_INVINCIBLE(playerVeh, true);
-	}
 
 	SET_PLAYER_WANTED_LEVEL(player, 0, false);
 	SET_PLAYER_WANTED_LEVEL_NOW(player, false);
 	SET_MAX_WANTED_LEVEL(0);
 
-	TeleportPlayer(destinationPos);
+	selectedLocationInfo.func();
+	//TeleportPlayer(destinationPos);
 
 	WAIT(g_Random.GetRandomInt(3500, 6000));
 


### PR DESCRIPTION
Fake TP now calls the `OnStart` function of the fake teleport effect.  This useful, incase some teleport effects need to execute some pre-teleport effects. This also is a replacement for checking the chosen location to execute other code. For example:
```
if (selectedLocationInfo.type == x)
{
     //Do stuff if chosen location is x
}
else 
{
     //Do stuff if chosen location isn't x
}
```
is replaced with:
```
selectedLocationInfo.func(); //The OnStart function
```

Of coarse you would need a OnStart function for this to work. Still teleports the player back as normal, nothing changed there. This is also good, if the code to teleport to a location is changed, you won't have to change it in the faketp effect.