### PR TITLE
Enhanced main timer

### DIFF
--- a/ChaosMod/Components/EffectDispatcher.cpp
+++ b/ChaosMod/Components/EffectDispatcher.cpp
@@ -78,20 +78,19 @@ void EffectDispatcher::OnRun()
 
 void EffectDispatcher::UpdateTimer()
 {
-	DWORD64 ullCurrentUpdateTime           = GetTickCount64();
-	static DWORD64 c_ullPreviousUpdateTime = ullCurrentUpdateTime;
+	DWORD64 ullCurrentUpdateTime = GetTickCount64();
 
 	if (!m_bEnableNormalEffectDispatch || m_bPauseTimer || MetaModifiers::m_bDisableChaos)
 	{
-		c_ullPreviousUpdateTime = ullCurrentUpdateTime;
+		m_ullTimerTimer = ullCurrentUpdateTime;
 		return;
 	}
 
-	m_fTimerPercentage += (ullCurrentUpdateTime - c_ullPreviousUpdateTime) * MetaModifiers::m_fTimerSpeedModifier
-	                    / m_usEffectSpawnTime / 1000;
-	c_ullPreviousUpdateTime = ullCurrentUpdateTime;
+	m_fTimerPercentage +=
+		(ullCurrentUpdateTime - m_ullTimerTimer) * MetaModifiers::m_fTimerSpeedModifier / m_usEffectSpawnTime / 1000;
+	m_ullTimerTimer = ullCurrentUpdateTime;
 
-	if (m_fTimerPercentage >= 1 && m_bDispatchEffectsOnTimer)
+	if (m_fTimerPercentage >= 1.f && m_bDispatchEffectsOnTimer)
 	{
 		DispatchRandomEffect();
 
@@ -100,7 +99,7 @@ void EffectDispatcher::UpdateTimer()
 			GetComponent<EffectDispatcher>()->DispatchRandomEffect();
 		}
 
-		m_fTimerPercentage = 0;
+		m_fTimerPercentage = 0.f;
 	}
 }
 
@@ -635,8 +634,12 @@ void EffectDispatcher::Reset()
 
 void EffectDispatcher::ResetTimer()
 {
+<<<<<<< HEAD
 	m_fTimerPercentage = 0;
 	m_ullEffectsTimer  = GetTickCount64();
+	== == == = m_fTimerPercentage = 0.f;
+	m_ullTimerTimer = m_ullEffectsTimer = GetTickCount64();
+>>>>>>> c52da04 (Fixed timer going on while mod is disabled)
 }
 
 float EffectDispatcher::GetEffectTopSpace()

--- a/ChaosMod/Components/EffectDispatcher.cpp
+++ b/ChaosMod/Components/EffectDispatcher.cpp
@@ -66,13 +66,11 @@ void EffectDispatcher::OnRun()
 
 	if (!m_bPauseTimer)
 	{
-		if (!MetaModifiers::m_bDisableChaos)
-		{
-			UpdateTimer();
-		}
 
 		UpdateMetaEffects();
 	}
+
+	UpdateTimer();
 
 	DrawTimerBar();
 	DrawEffectTexts();
@@ -80,38 +78,29 @@ void EffectDispatcher::OnRun()
 
 void EffectDispatcher::UpdateTimer()
 {
-	if (!m_bEnableNormalEffectDispatch)
+	DWORD64 ullCurrentUpdateTime           = GetTickCount64();
+	static DWORD64 c_ullPreviousUpdateTime = ullCurrentUpdateTime;
+
+	if (!m_bEnableNormalEffectDispatch || m_bPauseTimer || MetaModifiers::m_bDisableChaos)
 	{
+		c_ullPreviousUpdateTime = ullCurrentUpdateTime;
 		return;
 	}
 
-	DWORD64 ullCurrentUpdateTime = GetTickCount64();
+	m_fTimerPercentage += (ullCurrentUpdateTime - c_ullPreviousUpdateTime) * MetaModifiers::m_fTimerSpeedModifier
+	                    / m_usEffectSpawnTime / 1000;
+	c_ullPreviousUpdateTime = ullCurrentUpdateTime;
 
-	float fDelta                 = ullCurrentUpdateTime - m_ullTimerTimer;
-	if (fDelta > 1000.f)
-	{
-		m_usTimerTimerRuns++;
-
-		m_ullTimerTimer = ullCurrentUpdateTime;
-		fDelta          = 0;
-	}
-
-	if ((m_fPercentage = (fDelta + (m_usTimerTimerRuns * 1000))
-	                   / (m_usEffectSpawnTime / MetaModifiers::m_fTimerSpeedModifier * 1000))
-	        > 1.f
-	    && m_bDispatchEffectsOnTimer)
+	if (m_fTimerPercentage >= 1 && m_bDispatchEffectsOnTimer)
 	{
 		DispatchRandomEffect();
 
-		if (MetaModifiers::m_ucAdditionalEffectsToDispatch > 0)
+		for (BYTE ucIdx = 0; ucIdx < MetaModifiers::m_ucAdditionalEffectsToDispatch; ucIdx++)
 		{
-			for (BYTE ucIdx = 0; ucIdx < MetaModifiers::m_ucAdditionalEffectsToDispatch; ucIdx++)
-			{
-				GetComponent<EffectDispatcher>()->DispatchRandomEffect();
-			}
+			GetComponent<EffectDispatcher>()->DispatchRandomEffect();
 		}
 
-		m_usTimerTimerRuns = 0;
+		m_fTimerPercentage = 0;
 	}
 }
 
@@ -258,8 +247,8 @@ void EffectDispatcher::DrawTimerBar()
 		return;
 	}
 
-	float fPercentage =
-		m_fFakeTimerBarPercentage > 0.f && m_fFakeTimerBarPercentage <= 1.f ? m_fFakeTimerBarPercentage : m_fPercentage;
+	float fPercentage = m_fFakeTimerBarPercentage > 0.f && m_fFakeTimerBarPercentage <= 1.f ? m_fFakeTimerBarPercentage
+	                                                                                        : m_fTimerPercentage;
 
 	// New Effect Bar
 	DRAW_RECT(.5f, .01f, 1.f, .021f, 0, 0, 0, 127, false);
@@ -348,7 +337,7 @@ _NODISCARD bool EffectDispatcher::ShouldDispatchEffectNow() const
 
 _NODISCARD int EffectDispatcher::GetRemainingTimerTime() const
 {
-	return m_usEffectSpawnTime / MetaModifiers::m_fTimerSpeedModifier - m_usTimerTimerRuns;
+	return m_usEffectSpawnTime / MetaModifiers::m_fTimerSpeedModifier * (1 - m_fTimerPercentage);
 }
 
 void EffectDispatcher::DispatchEffect(const EffectIdentifier &effectIdentifier, const char *szSuffix, bool bAddToLog)
@@ -498,7 +487,6 @@ void EffectDispatcher::DispatchEffect(const EffectIdentifier &effectIdentifier, 
 			}
 		}
 	}
-	m_fPercentage = .0f;
 }
 
 void EffectDispatcher::DispatchRandomEffect(const char *szSuffix)
@@ -647,8 +635,7 @@ void EffectDispatcher::Reset()
 
 void EffectDispatcher::ResetTimer()
 {
-	m_ullTimerTimer    = GetTickCount64();
-	m_usTimerTimerRuns = 0;
+	m_fTimerPercentage = 0;
 	m_ullEffectsTimer  = GetTickCount64();
 }
 

--- a/ChaosMod/Components/EffectDispatcher.cpp
+++ b/ChaosMod/Components/EffectDispatcher.cpp
@@ -80,7 +80,8 @@ void EffectDispatcher::UpdateTimer()
 {
 	DWORD64 ullCurrentUpdateTime = GetTickCount64();
 
-	if (!m_bEnableNormalEffectDispatch || m_bPauseTimer || MetaModifiers::m_bDisableChaos)
+	if (!m_bEnableNormalEffectDispatch || m_bPauseTimer || MetaModifiers::m_bDisableChaos
+	    || ullCurrentUpdateTime - m_ullTimerTimer > 1000)
 	{
 		m_ullTimerTimer = ullCurrentUpdateTime;
 		return;
@@ -634,12 +635,8 @@ void EffectDispatcher::Reset()
 
 void EffectDispatcher::ResetTimer()
 {
-<<<<<<< HEAD
-	m_fTimerPercentage = 0;
-	m_ullEffectsTimer  = GetTickCount64();
-	== == == = m_fTimerPercentage = 0.f;
+	m_fTimerPercentage = 0.f;
 	m_ullTimerTimer = m_ullEffectsTimer = GetTickCount64();
->>>>>>> c52da04 (Fixed timer going on while mod is disabled)
 }
 
 float EffectDispatcher::GetEffectTopSpace()

--- a/ChaosMod/Components/EffectDispatcher.h
+++ b/ChaosMod/Components/EffectDispatcher.h
@@ -74,7 +74,7 @@ class EffectDispatcher : public Component
 
 	int m_iMaxRunningEffects             = 0;
 
-	float m_fTimerPercentage             = 0;
+	float m_fTimerPercentage             = 0.f;
 	float m_fEffectsInnerSpacingMax      = .075f;
 	float m_fEffectsInnerSpacingMin      = .030f;
 	float m_fEffectsTopSpacingDefault    = .2f;
@@ -87,6 +87,7 @@ class EffectDispatcher : public Component
 	bool m_bEnableNormalEffectDispatch = true;
 
 	DWORD64 m_ullEffectsTimer          = 0;
+	DWORD64 m_ullTimerTimer            = 0;
 
 	bool m_bMetaEffectsEnabled         = true;
 	DWORD64 m_ullMetaTimer             = 0;

--- a/ChaosMod/Components/EffectDispatcher.h
+++ b/ChaosMod/Components/EffectDispatcher.h
@@ -74,7 +74,7 @@ class EffectDispatcher : public Component
 
 	int m_iMaxRunningEffects             = 0;
 
-	float m_fPercentage                  = 0.f;
+	float m_fTimerPercentage             = 0;
 	float m_fEffectsInnerSpacingMax      = .075f;
 	float m_fEffectsInnerSpacingMin      = .030f;
 	float m_fEffectsTopSpacingDefault    = .2f;
@@ -86,8 +86,6 @@ class EffectDispatcher : public Component
 
 	bool m_bEnableNormalEffectDispatch = true;
 
-	DWORD64 m_ullTimerTimer            = 0;
-	WORD m_usTimerTimerRuns            = 0;
 	DWORD64 m_ullEffectsTimer          = 0;
 
 	bool m_bMetaEffectsEnabled         = true;


### PR DESCRIPTION
Current timer has several issues:
1. Meta effects "*x Timer Speed" multiplies not only the speed but also position of the bar.
2. Pausing and then unpausing the timer causes it to jump slightly.
3. Dispatching effect from the debug menu causes the bar to reset, although the timer still stays on its position.

This PR fixes all of them and also simplifies timer code.