### PR TITLE
Prevent softlocks with "No Phone"

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscNoPhone.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscNoPhone.cpp
@@ -2,21 +2,12 @@
 
 static void OnStop()
 {
-	REQUEST_SCRIPT("cellphone_controller");
-
-	while (!HAS_SCRIPT_LOADED("cellphone_controller"))
-	{
-		WAIT(0);
-	}
-
-	START_NEW_SCRIPT("cellphone_controller", 1424);
-
-	SET_SCRIPT_AS_NO_LONGER_NEEDED("cellphone_controller");
+	ENABLE_CONTROL_ACTION(0, 27, true);
 }
 
 static void OnTick()
 {
-	TERMINATE_ALL_SCRIPTS_WITH_THIS_NAME("cellphone_controller");
+	DISABLE_CONTROL_ACTION(0, 27, true);
 }
 
 static RegisterEffect registerEffect(EFFECT_NO_PHONE, nullptr, OnStop, OnTick, EffectInfo


### PR DESCRIPTION
Instead of terminating the phone script, which could cause softlocks on some missions. Will instead disable the player from opening the phone via `DISABLE_CONTROL_ACTION`.