### PR TITLE
Implemented debug shortcuts

### DIFF
--- a/ChaosMod/Effects/EffectConfig.h
+++ b/ChaosMod/Effects/EffectConfig.h
@@ -119,7 +119,11 @@ namespace EffectConfig
 			effectData.SetAttribute(EEffectAttributes::ExcludedFromVoting, rgValues[5]);
 			effectData.SetAttribute(EEffectAttributes::IsMeta, effectInfo.ExecutionType == EEffectExecutionType::Meta);
 			effectData.Name            = effectInfo.Name;
+#ifdef _DEBUG
+			effectData.ShortcutKeycode = effectInfo.DebugShortcutKeycode ? effectInfo.DebugShortcutKeycode : rgValues[7];
+#else
 			effectData.ShortcutKeycode = rgValues[7];
+#endif
 			if (!szValueEffectName.empty())
 			{
 				effectData.SetAttribute(EEffectAttributes::HasCustomName, true);

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -15,7 +15,7 @@ struct EffectInfo
 	bool IsTimed         = false;
 	bool IsShortDuration = false;
 #ifdef _DEBUG
-	int DebugShortcutKeycode;
+	int DebugShortcutKeycode = 0;
 #endif
 	std::vector<std::string_view> IncompatibleWith;
 	EEffectCategory EffectCategory     = EEffectCategory::None;

--- a/ChaosMod/Effects/EffectsInfo.h
+++ b/ChaosMod/Effects/EffectsInfo.h
@@ -14,6 +14,9 @@ struct EffectInfo
 	const char *Id;
 	bool IsTimed         = false;
 	bool IsShortDuration = false;
+#ifdef _DEBUG
+	int DebugShortcutKeycode;
+#endif
 	std::vector<std::string_view> IncompatibleWith;
 	EEffectCategory EffectCategory     = EEffectCategory::None;
 	EEffectGroupType EffectGroupType   = EEffectGroupType::None;


### PR DESCRIPTION
#### If the build configuration is set to debug:
You can set a debug shortcut for effects with `.DebugShortcutKeycode` in EffectInfo. This will override shortcuts read from the config file (if any), with the specified KeyCode. This saves time having to scroll through the debug menu.  I was originally going to do the same with the lua scripts (making the member only functional when using a debug build), but people writing lua scripts, don't necessarily have a debug build.

NOTE: The member doesn't exist in Release configuration.  