### PR TITLE
Added "Sticky Collision" effect

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -227,6 +227,7 @@
     <ClCompile Include="Effects\db\Player\PlayerLockCamera.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsRandomTraffic.cpp" />
     <ClCompile Include="Effects\db\Misc\MiscUTurn.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsStickyCollide.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsTiny.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsWeapons.cpp" />
     <ClCompile Include="Effects\db\Weather\WeatherSnow.cpp" />

--- a/ChaosMod/Effects/db/Vehs/VehsStickyCollide.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsStickyCollide.cpp
@@ -1,0 +1,41 @@
+/*
+	Effect By OnlyRealNubs
+*/
+
+#include "stdafx.h"
+
+std::vector<Vehicle> vehs;
+
+static void OnStop()
+{
+	for (Vehicle& veh : vehs)
+	{
+		FREEZE_ENTITY_POSITION(veh, false);
+	}
+}
+
+static void OnTick()
+{
+	for (Vehicle veh : GetAllVehs())
+	{
+		if (true)
+		{
+			if (HAS_ENTITY_COLLIDED_WITH_ANYTHING(veh))
+			{
+				LOG("COLLIDED");
+				FREEZE_ENTITY_POSITION(veh, true);
+				vehs.push_back(veh);
+			}
+		}
+	}
+}
+
+// clang-format off
+REGISTER_EFFECT(nullptr, OnStop, OnTick, EffectInfo
+	{
+		.Name = "Vehicles Have Sticky Collision",
+		.Id = "vehs_sticky_collide",
+		.IsTimed = true,
+		.IsShortDuration = true
+	}
+);

--- a/ConfigApp/Effects.cs
+++ b/ConfigApp/Effects.cs
@@ -373,6 +373,7 @@ namespace ConfigApp
             { "screen_colorfulworld", new EffectInfo("Colorful World", EffectCategory.Screen, true) },
             { "screen_arc", new EffectInfo("Arced Screen", EffectCategory.Screen, true, true) },
             { "world_blackhole", new EffectInfo("Black Hole", EffectCategory.Misc, true, true) },
+            { "vehs_sticky_collide", new EffectInfo("Vehicles Have Sticky Collision", EffectCategory.Vehicle, true, true) },
         };
     }
 }


### PR DESCRIPTION
When a vehicle collides, it will be frozen, as if it stuck to the surface it collided to. If collided with a vehicle, said vehicle will also be stuck.

(Actual name "Vehicles Have Sticky Collision". Shortened for title)