### PR TITLE
Added controller rumble to intense effects

### DIFF
--- a/ChaosMod/CMakeLists.txt
+++ b/ChaosMod/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 target_include_directories(ChaosMod PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/../vendor ${PROJECT_SOURCE_DIR}/../vendor/websocketpp)
 
-set(link_libs shv minhook lua54 winmm d3dcompiler)
+set(link_libs shv minhook lua54 winmm d3dcompiler xinput)
 
 if (WITH_DEBUG_PANEL_SUPPORT)
     set(link_libs ${link_libs} ixwebsocket wsock32 ws2_32)

--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -61,7 +61,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);winmm.lib;dbghelp.lib;d3dcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);winmm.lib;dbghelp.lib;d3dcompiler.lib;XInput.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -464,6 +464,7 @@
     <ClInclude Include="Util\Types.h" />
     <ClInclude Include="Util\Vehicle.h" />
     <ClInclude Include="Util\Weapon.h" />
+    <ClInclude Include="Util\XInput.h" />
     <ClInclude Include="Info.h" />
   </ItemGroup>
   <ItemGroup>

--- a/ChaosMod/Effects/db/Misc/MiscBlackHole.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscBlackHole.cpp
@@ -1,5 +1,7 @@
 #include <stdafx.h>
 
+#include "Util/XInput.h"
+
 static Vector3 ms_BlackHolePos;
 static float ms_fCurRadius;
 
@@ -13,8 +15,15 @@ static void OnStart()
 	ms_fCurRadius = 0.f;
 }
 
+static void OnStop()
+{
+	XInput::StopAllControllersRumble();
+}
+
 static void OnTick()
 {
+	XInput::SetAllControllersRumble(40000, 40000);
+
 	if (ms_fCurRadius < 200.f)
 	{
 		ms_fCurRadius += 0.2f + GET_FRAME_TIME();
@@ -74,7 +83,7 @@ static void OnTick()
 }
 
 // clang-format off
-REGISTER_EFFECT(OnStart, nullptr, OnTick, EffectInfo
+REGISTER_EFFECT(OnStart, OnStop, OnTick, EffectInfo
 	{
 		.Name = "Black Hole",
 		.Id = "world_blackhole",

--- a/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscEarthquake.cpp
@@ -5,14 +5,19 @@
 #include <stdafx.h>
 
 #include "Memory/Physics.h"
+#include "Util/XInput.h"
 
 static void OnStop()
 {
+	XInput::StopAllControllersRumble();
+
 	CAM::STOP_GAMEPLAY_CAM_SHAKING(true);
 }
 
 static void OnTick()
 {
+	XInput::SetAllControllersRumble(40000, 40000);
+
 	CAM::SHAKE_GAMEPLAY_CAM("LARGE_EXPLOSION_SHAKE", 0.05f);
 	float shook = GET_RANDOM_FLOAT_IN_RANGE(
 	    -9.f, 7.f); // low slightly lower than oppisite of upper to decrease chances of stuff going into space.

--- a/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscTotalChaos.cpp
@@ -1,6 +1,7 @@
 #include <stdafx.h>
 
 #include "Memory/Physics.h"
+#include "Util/XInput.h"
 
 static DWORD64 m_anchorTick;
 
@@ -13,6 +14,8 @@ static void OnStart()
 
 static void OnStop()
 {
+	XInput::StopAllControllersRumble();
+
 	CLEAR_WEATHER_TYPE_PERSIST();
 
 	SET_WEATHER_TYPE_NOW("EXTRASUNNY");
@@ -20,6 +23,8 @@ static void OnStop()
 
 static void OnTick()
 {
+	XInput::SetAllControllersRumble(40000, 40000);
+
 	Ped playerPed     = PLAYER_PED_ID();
 	Vehicle playerVeh = GET_VEHICLE_PED_IS_IN(playerPed, false);
 

--- a/ChaosMod/Util/XInput.h
+++ b/ChaosMod/Util/XInput.h
@@ -1,0 +1,46 @@
+#include "stdafx.h"
+
+#include <Xinput.h>
+
+namespace XInput
+{
+	//Doesn't include the new Xbox Series X|S rumbles
+	inline void SetControllerRumble(DWORD controllerId, int leftMotorSpeed, int rightMotorSpeed)
+	{
+		XINPUT_VIBRATION vibration;
+		ZeroMemory( &vibration, sizeof(XINPUT_VIBRATION) );
+
+		vibration.wLeftMotorSpeed = leftMotorSpeed;
+		vibration.wRightMotorSpeed = rightMotorSpeed;
+
+		XInputSetState( controllerId, &vibration );
+	}
+	
+	//Make sure you call stop, or it will rumble until the application closes.
+	inline void SetAllControllersRumble(int leftMotorSpeed, int rightMotorSpeed)
+	{
+		for (DWORD i = 0; i < XUSER_MAX_COUNT; i++)
+		{
+			SetControllerRumble(i, leftMotorSpeed, rightMotorSpeed);
+		}
+	}
+
+	inline void StopControllerRumble(DWORD controllerId)
+	{
+		XINPUT_VIBRATION vibration;
+		ZeroMemory( &vibration, sizeof(XINPUT_VIBRATION) );
+
+		vibration.wLeftMotorSpeed = 0;
+		vibration.wRightMotorSpeed = 0;
+
+		XInputSetState( controllerId, &vibration );
+	}
+
+	inline void StopAllControllersRumble()
+	{
+		for (DWORD i = 0; i < XUSER_MAX_COUNT; i++)
+		{
+			StopControllerRumble(i);
+		}
+	}
+}

--- a/ChaosMod/Util/XInput.h
+++ b/ChaosMod/Util/XInput.h
@@ -2,7 +2,7 @@
 
 #include <stdafx.h>
 
-#include <Xinput.h>
+#include <xinput.h>
 
 namespace XInput
 {

--- a/ChaosMod/Util/XInput.h
+++ b/ChaosMod/Util/XInput.h
@@ -1,4 +1,6 @@
-#include "stdafx.h"
+#pragma once
+
+#include <stdafx.h>
 
 #include <Xinput.h>
 

--- a/ChaosMod/Util/XInput.h
+++ b/ChaosMod/Util/XInput.h
@@ -10,12 +10,12 @@ namespace XInput
 	inline void SetControllerRumble(DWORD controllerId, int leftMotorSpeed, int rightMotorSpeed)
 	{
 		XINPUT_VIBRATION vibration;
-		ZeroMemory( &vibration, sizeof(XINPUT_VIBRATION) );
+		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
 
 		vibration.wLeftMotorSpeed = leftMotorSpeed;
 		vibration.wRightMotorSpeed = rightMotorSpeed;
 
-		XInputSetState( controllerId, &vibration );
+		XInputSetState(controllerId, &vibration);
 	}
 	
 	//Make sure you call stop, or it will rumble until the application closes.
@@ -30,12 +30,12 @@ namespace XInput
 	inline void StopControllerRumble(DWORD controllerId)
 	{
 		XINPUT_VIBRATION vibration;
-		ZeroMemory( &vibration, sizeof(XINPUT_VIBRATION) );
+		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
 
 		vibration.wLeftMotorSpeed = 0;
 		vibration.wRightMotorSpeed = 0;
 
-		XInputSetState( controllerId, &vibration );
+		XInputSetState(controllerId, &vibration);
 	}
 
 	inline void StopAllControllersRumble()


### PR DESCRIPTION
Added controller rumble (vibration) to intense effects like "Doomsday", "Earthquake" and "Black Hole".

Rumble doesn't need to be set each frame, but it is due to the game automatically stopping it when it rumbles the controller.

Uses [XInput](https://docs.microsoft.com/en-us/windows/win32/xinput/xinput-game-controller-apis-portal), because it is better than the `SET_PAD_SHAKE` native, as you can set different speeds for both left and right motors. Doesn't have the new rumble with the Xbox Series X|S controllers, only left and right.