### PR TITLE
Added basic ability to limit Twitch voting

### DIFF
--- a/ConfigApp/MainWindow.xaml
+++ b/ConfigApp/MainWindow.xaml
@@ -288,6 +288,13 @@
                                    HorizontalAlignment="Right" VerticalAlignment="Center" />
                             <CheckBox x:Name="twitch_user_random_voteable_enable" Width="60" Height="20" Grid.Row="1" Grid.Column="4"
                                       HorizontalAlignment="Left" VerticalAlignment="Center" VerticalContentAlignment="Center" />
+                            <Label x:Name="twitch_permitted_usernames_label" Content="Permitted Twitch usernames (separated by , )"
+                                Grid.Row="3" Grid.Column="2"
+                                HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,3,9,0" Grid.ColumnSpan="2" />
+                            <TextBox x:Name="twitch_permitted_usernames" Width="268" Height="20" Grid.Row="3" Grid.Column="4"
+                                HorizontalAlignment="Left" VerticalAlignment="Center"
+                                CommandManager.PreviewExecuted="NoCopyPastePreviewExecuted" ContextMenu="{x:Null}"
+                                Keyboard.PreviewKeyDown="NoSpacePreviewKeyDown" Margin="10,12,0,13" />
                         </Grid>
 
                         <Grid Grid.Row="2">

--- a/ConfigApp/MainWindow.xaml.cs
+++ b/ConfigApp/MainWindow.xaml.cs
@@ -198,6 +198,7 @@ namespace ConfigApp
             twitch_user_chance_system_enable.IsChecked = m_twitchFile.ReadValueBool("TwitchVotingChanceSystem", false);
             twitch_user_chance_system_retain_chance_enable.IsChecked = m_twitchFile.ReadValueBool("TwitchVotingChanceSystemRetainChance", true);
             twitch_user_random_voteable_enable.IsChecked = m_twitchFile.ReadValueBool("TwitchRandomEffectVoteableEnable", true);
+            twitch_permitted_usernames.Text = m_twitchFile.ReadValue("TwitchPermittedUsernames");
         }
 
         private void WriteTwitchFile()
@@ -211,6 +212,7 @@ namespace ConfigApp
             m_twitchFile.WriteValue("TwitchVotingChanceSystem", twitch_user_chance_system_enable.IsChecked.Value);
             m_twitchFile.WriteValue("TwitchVotingChanceSystemRetainChance", twitch_user_chance_system_retain_chance_enable.IsChecked.Value);
             m_twitchFile.WriteValue("TwitchRandomEffectVoteableEnable", twitch_user_random_voteable_enable.IsChecked.Value);
+            m_twitchFile.WriteValue("TwitchPermittedUsernames", twitch_permitted_usernames.Text);
 
             m_twitchFile.WriteFile();
         }
@@ -390,6 +392,7 @@ namespace ConfigApp
             twitch_user_chance_system_retain_chance_enable.IsEnabled = agreed;
             twitch_user_random_voteable_enable.IsEnabled = agreed;
             twitch_user_random_voteable_enable_label.IsEnabled = agreed;
+            twitch_permitted_usernames.IsEnabled = agreed;
         }
 
         private void OnlyNumbersPreviewTextInput(object sender, TextCompositionEventArgs e)

--- a/TwitchChatVotingProxy/ChaosModController.cs
+++ b/TwitchChatVotingProxy/ChaosModController.cs
@@ -27,6 +27,7 @@ namespace TwitchChatVotingProxy
         private EVotingMode? votingMode;
         private EOverlayMode? overlayMode;
         private IVotingReceiver votingReceiver;
+        private string[] permittedUsernames;
 
         public ChaosModController(
             IChaosPipeClient chaosPipe,
@@ -51,6 +52,7 @@ namespace TwitchChatVotingProxy
             votingMode = config.VotingMode;
             overlayMode = config.OverlayMode;
             retainInitialVotes = config.RetainInitalVotes;
+            permittedUsernames = config.PermittedTwitchUsernames;
 
             // Setup display update tick
             displayUpdateTick.Elapsed += DisplayUpdateTick;
@@ -220,6 +222,26 @@ namespace TwitchChatVotingProxy
         private void OnVoteReceiverMessage(object sender, OnMessageArgs e)
         {
             if (!voteRunning) return;
+
+            if (permittedUsernames.Length > 0)
+            {
+                bool found = false;
+
+                foreach (string name in permittedUsernames)
+                {
+                    // both have already been lowered in other methods, so this comparison is always case-insensitive
+                    if (name == e.Username)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    return;
+                }
+            }
 
             for (int i = 0; i < activeVoteOptions.Count; i++)
             {

--- a/TwitchChatVotingProxy/Config/Config.cs
+++ b/TwitchChatVotingProxy/Config/Config.cs
@@ -13,6 +13,7 @@ namespace TwitchChatVotingProxy.Config
         public static readonly string KEY_TWITCH_OVERLAY_MODE = "TwitchVotingOverlayMode";
         public static readonly string KEY_TWITCH_RETAIN_INITIAL_VOTES = "TwitchVotingChanceSystemRetainChance";
         public static readonly string KEY_TWITCH_VOTING_CHANCE_SYSTEM = "TwitchVotingChanceSystem";
+        public static readonly string KEY_TWITCH_PERMITTED_USERNAMES = "TwitchPermittedUsernames";
 
         public EOverlayMode? OverlayMode { get; set; }
         public int? OverlayServerPort { get; set; }
@@ -21,6 +22,7 @@ namespace TwitchChatVotingProxy.Config
         public string TwitchChannelName { get; set; }
         public string TwitchOAuth { get; set; }
         public string TwitchUserName { get; set; }
+        public string[] PermittedTwitchUsernames { get; set; }
 
         private ILogger logger = Log.Logger.ForContext<Config>();
         private OptionsFile optionsFile;
@@ -44,6 +46,23 @@ namespace TwitchChatVotingProxy.Config
                 TwitchUserName = optionsFile.ReadValue(KEY_TWITCH_CHANNEL_USER_NAME);
                 VotingMode = optionsFile.ReadValueInt(KEY_TWITCH_VOTING_CHANCE_SYSTEM, 0) == 0 ? EVotingMode.MAJORITY : EVotingMode.PERCENTAGE;
                 OverlayMode = (EOverlayMode)optionsFile.ReadValueInt(KEY_TWITCH_OVERLAY_MODE, 0);
+
+                string tmpPermittedUsernames = optionsFile.ReadValue(KEY_TWITCH_PERMITTED_USERNAMES, "").Trim().ToLower();  // lower case the username to allow case-insensitive comparisons
+
+                if (tmpPermittedUsernames.Length > 0)
+                {
+                    PermittedTwitchUsernames = tmpPermittedUsernames.Split(',');
+
+                    for (var i = 0; i < PermittedTwitchUsernames.Length; i++)
+                    {
+                        // remove any potential whitespaces around the usernames
+                        PermittedTwitchUsernames[i] = PermittedTwitchUsernames[i].Trim();
+                    }
+                }
+                else
+                {
+                    PermittedTwitchUsernames = new string[0];
+                }
             }
         }
     }

--- a/TwitchChatVotingProxy/Config/IConfig.cs
+++ b/TwitchChatVotingProxy/Config/IConfig.cs
@@ -15,5 +15,6 @@ namespace TwitchChatVotingProxy.Config
         string TwitchChannelName { get; set; }
         string TwitchOAuth { get; set; }
         string TwitchUserName { get; set; }
+        public string[] PermittedTwitchUsernames { get; set; }
     }
 }

--- a/TwitchChatVotingProxy/TwitchVotingReceiver.cs
+++ b/TwitchChatVotingProxy/TwitchVotingReceiver.cs
@@ -105,6 +105,7 @@ namespace TwitchChatVotingProxy.VotingReceiver
             var evnt = new OnMessageArgs();
             evnt.Message = chatMessage.Message.Trim();
             evnt.ClientId = chatMessage.UserId;
+            evnt.Username = chatMessage.Username.ToLower(); // lower case the username to allow case-insensitive comparisons
             OnMessage.Invoke(this, evnt);
         }
     }

--- a/TwitchChatVotingProxy/VotingReceiver/OnMessageArgs.cs
+++ b/TwitchChatVotingProxy/VotingReceiver/OnMessageArgs.cs
@@ -8,5 +8,6 @@
     {
         public string ClientId { get; set; }
         public string Message { get; set; }
+        public string Username { get; set; }
     }
 }


### PR DESCRIPTION
Config app updated with an additional text field that lets you enter Twitch usernames.

The voting proxy now only counts votes from those users unless the field is empty.