### PR TITLE
Update "PatchFilterDLC" from FiveM to fix possible crashes of new update

### DIFF
--- a/ChaosMod/Memory/Hooks/ApplyChangeSetEntryHook.cpp
+++ b/ChaosMod/Memory/Hooks/ApplyChangeSetEntryHook.cpp
@@ -2,7 +2,7 @@
 
 #include "Memory/Hooks/Hook.h"
 
-// Thanks to FiveM
+// Thanks to FiveM - https://github.com/citizenfx/fivem/blob/master/code/components/gta-core-five/src/PatchFilterDLC.cpp
 struct ChangeSetEntry
 {
 	struct DataFile
@@ -39,6 +39,19 @@ void HK_ApplyChangeSetEntryStub(ChangeSetEntry *entry)
 		"dlc_mpG9EC:/x64/models/cdimages/mpg9ec_male.rpf",
 		"dlc_mpG9ECCRC:/common/data/mp_f_freemode_01_mpg9ec_shop.meta",
 		"dlc_mpG9EC:/x64/models/cdimages/mpg9ec_female.rpf",
+
+		"dlc_mpSum2_g9ec:/x64/levels/mpsum2_g9ec/vehiclemods/feltzer3hsw_mods.rpf",
+		"dlc_mpSum2_g9ec:/x64/levels/mpsum2_g9ec/vehiclemods/vigero2hsw_mods.rpf",
+		"dlc_mpSum2_g9ec:/x64/models/cdimages/mpSum2_g9ec_female.rpf",
+		"dlc_mpSum2_g9ec:/x64/models/cdimages/mpSum2_g9ec_female_p.rpf",
+		"dlc_mpSum2_g9ec:/x64/models/cdimages/mpSum2_g9ec_male.rpf",
+		"dlc_mpSum2_g9ec:/x64/models/cdimages/mpSum2_g9ec_male_p.rpf",
+		"dlc_mpSum2_g9ecCRC:/common/data/mp_f_freemode_01_mpSum2_g9ec_shop.meta",
+		"dlc_mpSum2_g9ecCRC:/common/data/mp_m_freemode_01_mpSum2_g9ec_shop.meta",
+		"dlc_mpSum2_g9ec:/x64/anim/creaturemetadata.rpf",
+		"dlc_mpSum2_g9ec:/common/data/effects/peds/first_person_alternates.meta",
+		"dlc_mpSum2_g9ec:/common/data/effects/peds/first_person.meta",
+		"dlc_mpSum2_g9ecCRC:/common/data/pedalternatevariations.meta",
 	};
 
 	if (entry->type == 6 || entry->type == 7 || !entry->dataFile || !badFiles.contains(entry->dataFile->name))


### PR DESCRIPTION
Took broken DLC-Parts from https://github.com/citizenfx/fivem/blob/master/code/components/gta-core-five/src/PatchFilterDLC.cpp