### PR TITLE
Prevents possible softlock where player ends up in a train

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsIntoRandomVehs.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsIntoRandomVehs.cpp
@@ -30,7 +30,7 @@ static void OnStart()
 		for (Vehicle veh : GetAllVehs())
 		{
 			if (ARE_ANY_VEHICLE_SEATS_FREE(veh) && IS_VEHICLE_DRIVEABLE(veh, true)
-			    && GET_ENTITY_HEIGHT_ABOVE_GROUND(veh) >= 0)
+			    && GET_ENTITY_HEIGHT_ABOVE_GROUND(veh) >= 0 && !IS_THIS_MODEL_A_TRAIN(GET_ENTITY_MODEL(veh)))
 			{
 				vehs.push_back(veh);
 			}

--- a/ChaosMod/Effects/db/Player/PlayerSetIntoClosestVeh.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerSetIntoClosestVeh.cpp
@@ -11,7 +11,7 @@ static void OnStart()
 	float closestDist  = 9999.f;
 	for (Vehicle veh : GetAllVehs())
 	{
-		if (veh == playerVeh)
+		if (veh == playerVeh || IS_THIS_MODEL_A_TRAIN(GET_ENTITY_MODEL(veh)))
 		{
 			continue;
 		}

--- a/ChaosMod/Effects/db/Player/PlayerSetIntoRandomVeh.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerSetIntoRandomVeh.cpp
@@ -13,7 +13,7 @@ static void OnStart()
 	{
 		Vector3 vehPos = GET_ENTITY_COORDS(veh, false);
 		if (veh != playerVeh && GET_GROUND_Z_FOR_3D_COORD(vehPos.x, vehPos.y, vehPos.z, &groundZ, false, false)
-		    && HAS_COLLISION_LOADED_AROUND_ENTITY(veh))
+		    && HAS_COLLISION_LOADED_AROUND_ENTITY(veh) && !IS_THIS_MODEL_A_TRAIN(GET_ENTITY_MODEL(veh)))
 		{
 			vehs.push_back(veh);
 		}


### PR DESCRIPTION
Effects "Set Everyone into Random Vehicles", "Set Player into Closest Vehicle" and "Set Player into Random Vehicle" may put the player in a train, which would cause a softlock because the player cannot leave the train.

This PR prevents the above-mentioned softlock.