### PR TITLE
Fake Crash Update

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscFakeCrash.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscFakeCrash.cpp
@@ -70,6 +70,7 @@ static void OnStart()
 	}
 
 	SleepAllThreads(g_Random.GetRandomInt(3000, 10000));
+	ShowWindow(GetForegroundWindow(), SW_MINIMIZE);
 
 	if (fakeTimer)
 	{


### PR DESCRIPTION
Fake Crash will now minimize the GTA window after the sleep time ends.