### PR TITLE
Fixed mouse steering with "Disable Random Direction"

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerNoMovRandom.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerNoMovRandom.cpp
@@ -1,5 +1,5 @@
 /*
-    Effect by Moxi
+    Effect by Moxi, modified
 */
 
 #include <stdafx.h>
@@ -85,6 +85,7 @@ static void OnTick()
 		DISABLE_CONTROL_ACTION(0, 133, true);
 		DISABLE_CONTROL_ACTION(0, 152, true);
 		DISABLE_CONTROL_ACTION(0, 278, true);
+		DISABLE_CONTROL_ACTION(0, 106, true);
 	}
 	else // Disable Right
 	{
@@ -108,6 +109,7 @@ static void OnTick()
 		DISABLE_CONTROL_ACTION(0, 134, true);
 		DISABLE_CONTROL_ACTION(0, 153, true);
 		DISABLE_CONTROL_ACTION(0, 279, true);
+		DISABLE_CONTROL_ACTION(0, 106, true);
 	}
 }
 


### PR DESCRIPTION
Originally you could easily get around Disable Random Direction by using mouse steering. This PR fixes that.