### PR TITLE
Remove my Deadname from effects I've created & use my current name

### DIFF
--- a/ChaosMod/Effects/db/Peds/PedsBloody.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsBloody.cpp
@@ -1,5 +1,5 @@
 /*
-    Effect by ubscal
+    Effect by Lunascape
 */
 
 #include <stdafx.h>

--- a/ChaosMod/Effects/db/Peds/PedsMowerMates.cpp
+++ b/ChaosMod/Effects/db/Peds/PedsMowerMates.cpp
@@ -1,4 +1,4 @@
-// Effect by ubscal, modified from Bus Bois, modified by Last0xygen
+// Effect by Lunascape, modified from Bus Bois, modified by Last0xygen
 
 #include <stdafx.h>
 

--- a/ChaosMod/Effects/db/Vehs/VehsRepossession.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsRepossession.cpp
@@ -1,5 +1,5 @@
 /*
-    Effect by ubscal, modified from Jesus take the wheel
+    Effect by Lunascape, modified from Jesus take the wheel
 */
 
 #include <stdafx.h>


### PR DESCRIPTION
Since I've created these effects I've come out as transgender and have been moving all my online identities to my new username and I am trying to minimize my old one. It would be extremely appreciated if this pull request was merged so my deadname isn't in the credits for these effects. Thank you very much.