### PR TITLE
Fixed player switch effects with ScriptThreadBlock.

### DIFF
--- a/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
+++ b/ChaosMod/Memory/Hooks/ScriptThreadRunHook.cpp
@@ -151,6 +151,10 @@ namespace Hooks
 	void EnableScriptThreadBlock()
 	{
 		ms_bEnabledHook = true;
+
+		//Fix the player switch effects when enabling
+		ANIMPOSTFX_STOP_ALL();
+		SET_TIME_SCALE(1.f);
 	}
 
 	void DisableScriptThreadBlock()


### PR DESCRIPTION
Previously you could hold the character switch button, then activate an effect that uses ScriptThreadBlock (an example would be Blimp Strats). And the wheel would be disabled, but the screen effects and slow-mo would still be active. That would be the case until DisableScriptThreadBlock is called. 

This fixes that by setting the time scale to full and stopping all screen effects that frame.