### PR TITLE
Make Quick Sprunk Stop Machine Functional

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscQuickSprunkStop.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscQuickSprunkStop.cpp
@@ -4,6 +4,8 @@
 
 #include <stdafx.h>
 
+static const char *scriptName = "ob_vend1";
+
 static void OnStart()
 {
 	static Hash objectHash = "prop_vend_soda_02"_hash;
@@ -12,6 +14,13 @@ static void OnStart()
 	Object obj             = CreatePoolProp(objectHash, pos.x, pos.y, pos.z, false);
 	PLACE_OBJECT_ON_GROUND_PROPERLY(obj);
 	SET_ENTITY_ROTATION(obj, GET_ENTITY_PITCH(player), -GET_ENTITY_ROLL(player), GET_ENTITY_HEADING(player), 0, true);
+
+	REQUEST_SCRIPT(scriptName);
+	while (!HAS_SCRIPT_LOADED(scriptName))
+	{
+		WAIT(0);
+	}
+	START_NEW_SCRIPT_WITH_ARGS(scriptName, (Any *)&obj, 1, 512);
 }
 
 // clang-format off


### PR DESCRIPTION
You can now drink Sprunk from the machine. Max of 20 total machines, this includes ones spawned by the game.