### PR TITLE
Improve Fake Death Effect

### DIFF
--- a/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
@@ -44,8 +44,6 @@ static void OnStart()
 	nextModeTime = 0;
 	isOnMission  = GET_MISSION_FLAG();
 
-	REQUEST_SCRIPT_AUDIO_BANK("WastedSounds", false, -1);
-	REQUEST_SCRIPT_AUDIO_BANK("MissionFailedSounds", false, -1);
 	REQUEST_SCRIPT_AUDIO_BANK("OFFMISSION_WASTED", false, -1);
 
 	Hooks::EnableScriptThreadBlock();

--- a/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
@@ -35,7 +35,6 @@ static const char *playerDeathName    = "";
 
 static void OnStart()
 {
-	soundId        = GET_SOUND_ID();
 	bool cancelledDeathAnim = false;
 
 	scaleForm    = 0;
@@ -43,6 +42,7 @@ static void OnStart()
 	lastModeTime = 0;
 	nextModeTime = 0;
 	isOnMission  = GET_MISSION_FLAG();
+	soundId      = GET_SOUND_ID();
 
 	REQUEST_SCRIPT_AUDIO_BANK("OFFMISSION_WASTED", false, -1);
 

--- a/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
@@ -28,7 +28,7 @@ static int scaleForm                  = 0;
 static int currentMode                = FakeDeathState::start;
 static int lastModeTime               = 0;
 static int nextModeTime               = 0;
-static int soundId                    = 0; //Using a Sound Id fixes some of the audio issues
+static int soundId                    = 0;
 static bool isOnMission               = false;
 static const char *deathAnimationName = "";
 static const char *playerDeathName    = "";
@@ -244,7 +244,7 @@ static void OnStart()
 			SET_VEHICLE_FIXED(veh);
 			STOP_ANIM_TASK(playerPed, "mp_suicide", "pistol", 3);
 			ANIMPOSTFX_STOP("DeathFailOut");
-			STOP_AUDIO_SCENE("DEATH_SCENE");
+			STOP_AUDIO_SCENE(isOnMission ? "MISSION_FAILED_SCENE" : "DEATH_SCENE");
 			SET_TIME_SCALE(1);
 			STOP_GAMEPLAY_CAM_SHAKING(true);
 			REMOVE_ANIM_DICT("mp_suicide");
@@ -254,6 +254,8 @@ static void OnStart()
 		}
 	}
 
+	RELEASE_SOUND_ID(soundId);
+	RELEASE_NAMED_SCRIPT_AUDIO_BANK("OFFMISSION_WASTED");
 	Hooks::DisableScriptThreadBlock();
 }
 

--- a/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
+++ b/ChaosMod/Effects/db/Player/PlayerFakeDeath.cpp
@@ -86,7 +86,6 @@ static void OnStart()
 		switch (currentMode)
 		{
 		case FakeDeathState::animation: // Play either the suicide animation or an explosion if in vehicle
-
 			if (g_Random.GetRandomInt(0, 1) % 2 == 0)
 			{
 				if (!IS_PED_IN_ANY_VEHICLE(playerPed, false))
@@ -176,6 +175,7 @@ static void OnStart()
 
 			// Set the fake name accordingly
 			GetComponent<EffectDispatcher>()->OverrideEffectNameId("player_fakedeath", fakeEffectId);
+
 			nextModeTime = 0;
 
 			if (cancelledDeathAnim)


### PR DESCRIPTION
Re-open #3030 

- Says mission failed on missions and plays mission failed sound 
- You no longer "die" if you dive out of your detonating vehicle
- Fixed issues with the sound effects (specifically TextHit)