### PR TITLE
Add ability to change OBS voting overlay bar progression color

### DIFF
--- a/ConfigApp/MainWindow.xaml
+++ b/ConfigApp/MainWindow.xaml
@@ -285,10 +285,17 @@
                             <TextBlock x:Name="twitch_user_overlay_mode_label" Text="Voting Overlay Mode" Grid.Row="0" Grid.Column="2"
                                    HorizontalAlignment="Right" VerticalAlignment="Center" />
                             <ComboBox x:Name="twitch_user_overlay_mode" Width="120" Height="25" Grid.Row="0" Grid.Column="4"
-                                      HorizontalAlignment="Left" VerticalAlignment="Center" />
-                            <TextBlock x:Name="twitch_user_random_voteable_enable_label" Text="Enable &quot;Random Effect&quot; voteable option" Grid.Row="1" Grid.Column="2"
+                                      HorizontalAlignment="Left" VerticalAlignment="Center" SelectionChanged="twitch_user_overlay_mode_changed" />
+                            <TextBlock x:Name="twitch_user_overlay_bar_color_label" Text="Voting Overlay Bar Progression" Grid.Row="1" Grid.Column="2"
                                    HorizontalAlignment="Right" VerticalAlignment="Center" />
-                            <CheckBox x:Name="twitch_user_random_voteable_enable" Width="60" Height="20" Grid.Row="1" Grid.Column="4"
+                            <xctk:ColorPicker Name="twitch_user_overlay_bar_color" Width="60" Height="25" Grid.Row="1" Grid.Column="4"
+                                          HorizontalAlignment="Left" VerticalAlignment="Center"
+                                          SelectedColor="#238BEB" ShowStandardColors="False" UsingAlphaChannel="False" Margin="0,8,0,7" IsEnabled="False" />
+                            <Button x:Name="twitch_user_overlay_bar_color_reset_button" Content="Reset" Width="60" Height="25" Grid.Row="1" Grid.Column="4"
+                                          HorizontalAlignment="Left" VerticalAlignment="Center" Margin="70,8,0,7" IsEnabled="False" Click="twitch_user_overlay_bar_color_reset_Click"/>
+                            <TextBlock x:Name="twitch_user_random_voteable_enable_label" Text="Enable &quot;Random Effect&quot; voteable option" Grid.Row="2" Grid.Column="2"
+                                   HorizontalAlignment="Right" VerticalAlignment="Center" />
+                            <CheckBox x:Name="twitch_user_random_voteable_enable" Width="60" Height="20" Grid.Row="2" Grid.Column="4"
                                       HorizontalAlignment="Left" VerticalAlignment="Center" VerticalContentAlignment="Center" />
                             <TextBlock x:Name="twitch_permitted_usernames_label" Text="Permitted Twitch usernames (separated by , )"
                                 Grid.Row="3" Grid.Column="2"

--- a/ConfigApp/MainWindow.xaml.cs
+++ b/ConfigApp/MainWindow.xaml.cs
@@ -209,6 +209,10 @@ namespace ConfigApp
             twitch_user_channel_oauth.Password = m_TwitchFile.ReadValue("TwitchChannelOAuth");
             twitch_user_effects_secs_before_chat_voting.Text = m_TwitchFile.ReadValue("TwitchVotingSecsBeforeVoting", "0");
             twitch_user_overlay_mode.SelectedIndex = m_TwitchFile.ReadValueInt("TwitchVotingOverlayMode", 0);
+            if (m_ConfigFile.HasKey("OverlayVotingBarColor"))
+            {
+                twitch_user_overlay_bar_color.SelectedColor = (Color)ColorConverter.ConvertFromString(m_TwitchFile.ReadValue("TwitchVotingOverlayBarColor"));
+            }
             twitch_user_chance_system_enable.IsChecked = m_TwitchFile.ReadValueBool("TwitchVotingChanceSystem", false);
             twitch_user_chance_system_retain_chance_enable.IsChecked = m_TwitchFile.ReadValueBool("TwitchVotingChanceSystemRetainChance", true);
             twitch_user_random_voteable_enable.IsChecked = m_TwitchFile.ReadValueBool("TwitchRandomEffectVoteableEnable", true);
@@ -223,6 +227,7 @@ namespace ConfigApp
             m_TwitchFile.WriteValue("TwitchChannelOAuth", twitch_user_channel_oauth.Password);
             m_TwitchFile.WriteValue("TwitchVotingSecsBeforeVoting", twitch_user_effects_secs_before_chat_voting.Text);
             m_TwitchFile.WriteValue("TwitchVotingOverlayMode", twitch_user_overlay_mode.SelectedIndex);
+            m_TwitchFile.WriteValue("TwitchVotingOverlayBarColor", twitch_user_overlay_bar_color.SelectedColor.ToString());
             m_TwitchFile.WriteValue("TwitchVotingChanceSystem", twitch_user_chance_system_enable.IsChecked.Value);
             m_TwitchFile.WriteValue("TwitchVotingChanceSystemRetainChance", twitch_user_chance_system_retain_chance_enable.IsChecked.Value);
             m_TwitchFile.WriteValue("TwitchRandomEffectVoteableEnable", twitch_user_random_voteable_enable.IsChecked.Value);
@@ -399,6 +404,8 @@ namespace ConfigApp
             twitch_user_effects_secs_before_chat_voting.IsEnabled = agreed;
             twitch_user_overlay_mode_label.IsEnabled = agreed;
             twitch_user_overlay_mode.IsEnabled = agreed;
+            twitch_user_overlay_bar_color.IsEnabled = agreed && twitch_user_overlay_mode.SelectedIndex == 2;
+            twitch_user_overlay_bar_color_reset_button.IsEnabled = agreed && twitch_user_overlay_mode.SelectedIndex == 2;
             twitch_user_chance_system_enable_label.IsEnabled = agreed;
             twitch_user_chance_system_enable.IsEnabled = agreed;
             twitch_user_chance_system_retain_chance_enable_label.IsEnabled = agreed;
@@ -469,6 +476,28 @@ namespace ConfigApp
         private void twitch_user_agreed_Click(object sender, RoutedEventArgs e)
         {
             TwitchTabHandleAgreed();
+        }
+
+        private void twitch_user_overlay_mode_changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (!twitch_user_overlay_bar_color.IsEnabled && twitch_user_overlay_mode.SelectedIndex == 2 && twitch_user_agreed.IsChecked.GetValueOrDefault())
+            {
+                twitch_user_overlay_bar_color.IsEnabled = true;
+                twitch_user_overlay_bar_color_reset_button.IsEnabled = true;
+            }
+            else
+            {
+                twitch_user_overlay_bar_color.IsEnabled = false;
+                twitch_user_overlay_bar_color_reset_button.IsEnabled = false;
+            }
+        }
+
+        private void twitch_user_overlay_bar_color_reset_Click(object sender, RoutedEventArgs e)
+        {
+            if (twitch_user_overlay_bar_color.IsEnabled && twitch_user_overlay_mode.SelectedIndex == 2)
+            {
+                twitch_user_overlay_bar_color.SelectedColor = (Color)ColorConverter.ConvertFromString("#238BEB");
+            }
         }
 
         private void effect_user_config_Click(object sender, RoutedEventArgs e)

--- a/TwitchChatVotingProxy/Config/Config.cs
+++ b/TwitchChatVotingProxy/Config/Config.cs
@@ -1,12 +1,14 @@
 ﻿using Serilog;
 using Shared;
 using System.IO;
+using System.Windows.Media;
 
 namespace TwitchChatVotingProxy.Config
 {
     class Config : IConfig
     {
         public static readonly string KEY_OVERLAY_SERVER_PORT = "OverlayServerPort";
+        public static readonly string KEY_OVERLAY_VOTING_BAR_COLOR = "TwitchVotingOverlayBarColor";
         public static readonly string KEY_TWITCH_CHANNEL_NAME = "TwitchChannelName"; 
         public static readonly string KEY_TWITCH_CHANNEL_OAUTH = "TwitchChannelOAuth";
         public static readonly string KEY_TWITCH_CHANNEL_USER_NAME = "TwitchUserName";
@@ -17,6 +19,7 @@ namespace TwitchChatVotingProxy.Config
 
         public EOverlayMode? OverlayMode { get; set; }
         public int? OverlayServerPort { get; set; }
+        public Color? OverlayVotingBarColor { get; set; }
         public bool RetainInitalVotes { get; set; }
         public EVotingMode? VotingMode { get; set; }
         public string TwitchChannelName { get; set; }
@@ -40,6 +43,11 @@ namespace TwitchChatVotingProxy.Config
 
                 OverlayServerPort = optionsFile.ReadValueInt(KEY_OVERLAY_SERVER_PORT, -1);
                 if (OverlayServerPort == -1) OverlayServerPort = null;
+                if (optionsFile.HasKey("OverlayVotingBarColor"))
+                {
+                    OverlayVotingBarColor = (Color)ColorConverter.ConvertFromString(optionsFile.ReadValue(KEY_OVERLAY_VOTING_BAR_COLOR));
+                }
+                else { OverlayVotingBarColor = null; }
                 RetainInitalVotes = optionsFile.ReadValueBool(KEY_TWITCH_RETAIN_INITIAL_VOTES, false);
                 TwitchChannelName = optionsFile.ReadValue(KEY_TWITCH_CHANNEL_NAME);
                 TwitchOAuth = optionsFile.ReadValue(KEY_TWITCH_CHANNEL_OAUTH);
@@ -63,6 +71,8 @@ namespace TwitchChatVotingProxy.Config
                 {
                     PermittedTwitchUsernames = new string[0];
                 }
+
+                logger.Information("auccesfully read twitch voting config");
             }
         }
     }

--- a/TwitchChatVotingProxy/OverlayServer/OverlayMessage.cs
+++ b/TwitchChatVotingProxy/OverlayServer/OverlayMessage.cs
@@ -1,9 +1,33 @@
-﻿namespace TwitchChatVotingProxy.OverlayServer
+﻿using System.Windows.Media;
+
+namespace TwitchChatVotingProxy.OverlayServer
 {
+    enum eMessageType : int
+    {
+        NONE = -1,
+        SET_VOTES,
+        SET_COLOR
+    }
+
     /// <summary>
-    /// Message which is being sent 
+    /// Universal container for voting overlay message data
     /// </summary>
-    class OverlayMessage
+    class OverlayBaseMessage
+    {
+        /// <summary>
+        /// The type of the message request. This is read by the overlay to properly parse the correct request message.
+        /// </summary>
+        public string type { get; set; }
+        /// <summary>
+        /// The json data (serialized) of the actual request
+        /// </summary>
+        public string messageData { get; set; }
+    }
+
+    /// <summary>
+    /// Message containing voting data
+    /// </summary>
+    class OverlayVotingMessage
     {
         public bool retainInitialVotes { get; set; }
         /// <summary>
@@ -22,5 +46,24 @@
         /// Voting options them self
         /// </summary>
         public OverlayVoteOption[] voteOptions { get; set; }
+    }
+
+    /// <summary>
+    /// Message to tell the voting overlay to update the style color for the bar progression
+    /// </summary>
+    class OverlayColorMessage
+    {
+        /// <summary>
+        /// Red value of the style color
+        /// </summary>
+        public int colorR;
+        /// <summary>
+        /// Green value of the style color
+        /// </summary>
+        public int colorG;
+        /// <summary>
+        /// Blue value of the style color
+        /// </summary>
+        public int colorB;
     }
 }

--- a/TwitchChatVotingProxy/OverlayServer/OverlayServer.cs
+++ b/TwitchChatVotingProxy/OverlayServer/OverlayServer.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Windows.Media;
 
 // TODO: fix voting mode
 namespace TwitchChatVotingProxy.OverlayServer
@@ -37,12 +38,12 @@ namespace TwitchChatVotingProxy.OverlayServer
 
         public void SendSetBarColorMessage()
         {
-            if (config.OverlayVotingBarColor != null)
+            if (config.OverlayVotingBarColor.HasValue)
             {
                 var clrMsg = new OverlayColorMessage();
-                clrMsg.colorR = config.OverlayVotingBarColor.R;
-                clrMsg.colorG = config.OverlayVotingBarColor.G;
-                clrMsg.colorB = config.OverlayVotingBarColor.B;
+                clrMsg.colorR = ((Color)config.OverlayVotingBarColor).R;
+                clrMsg.colorG = ((Color)config.OverlayVotingBarColor).G;
+                clrMsg.colorB = ((Color)config.OverlayVotingBarColor).B;
 
                 Broadcast(eMessageType.SET_COLOR, JsonConvert.SerializeObject(clrMsg));
             }

--- a/TwitchChatVotingProxy/OverlayServer/OverlayServerConfig.cs
+++ b/TwitchChatVotingProxy/OverlayServer/OverlayServerConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Windows.Media;
 
 namespace TwitchChatVotingProxy.OverlayServer
 {
@@ -14,12 +10,14 @@ namespace TwitchChatVotingProxy.OverlayServer
         public bool RetainInitialVotes { get; set; }
         public EVotingMode VotingMode { get; set; }
         public int Port { get; set; }
+        public Color OverlayVotingBarColor { get; set; }
 
-        public OverlayServerConfig(EVotingMode votingMode, bool retainInitialVotes, int? port)
+        public OverlayServerConfig(EVotingMode votingMode, bool retainInitialVotes, int? port, Color overlayVotingBarColor)
         {
             RetainInitialVotes = retainInitialVotes;
             VotingMode = votingMode;
             Port = port == null ? 9091 : (int)port;
+            OverlayVotingBarColor = overlayVotingBarColor;
         }
     }
 }

--- a/TwitchChatVotingProxy/OverlayServer/OverlayServerConfig.cs
+++ b/TwitchChatVotingProxy/OverlayServer/OverlayServerConfig.cs
@@ -10,9 +10,9 @@ namespace TwitchChatVotingProxy.OverlayServer
         public bool RetainInitialVotes { get; set; }
         public EVotingMode VotingMode { get; set; }
         public int Port { get; set; }
-        public Color OverlayVotingBarColor { get; set; }
+        public Color? OverlayVotingBarColor { get; set; }
 
-        public OverlayServerConfig(EVotingMode votingMode, bool retainInitialVotes, int? port, Color overlayVotingBarColor)
+        public OverlayServerConfig(EVotingMode votingMode, bool retainInitialVotes, int? port, Color? overlayVotingBarColor)
         {
             RetainInitialVotes = retainInitialVotes;
             VotingMode = votingMode;

--- a/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
+++ b/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
@@ -67,7 +67,6 @@ namespace TwitchChatVotingProxy
                 if (config.OverlayMode == EOverlayMode.OVERLAY_OBS)
                 {
                     // Create overlay server config
-                    //OverlayServerConfig overlayServerConfig = new OverlayServerConfig(votingMode, config.RetainInitalVotes, config.OverlayServerPort);
                     OverlayServerConfig overlayServerConfig = new OverlayServerConfig(votingMode, config.RetainInitalVotes, config.OverlayServerPort, config.OverlayVotingBarColor);
 
                     // Create component

--- a/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
+++ b/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
@@ -67,10 +67,13 @@ namespace TwitchChatVotingProxy
                 if (config.OverlayMode == EOverlayMode.OVERLAY_OBS)
                 {
                     // Create overlay server config
-                    OverlayServerConfig overlayServerConfig = new OverlayServerConfig(votingMode, config.RetainInitalVotes, config.OverlayServerPort);
+                    //OverlayServerConfig overlayServerConfig = new OverlayServerConfig(votingMode, config.RetainInitalVotes, config.OverlayServerPort);
+                    OverlayServerConfig overlayServerConfig = new OverlayServerConfig(votingMode, config.RetainInitalVotes, config.OverlayServerPort, config.OverlayVotingBarColor);
 
                     // Create component
                     overlayServer = new OverlayServer.OverlayServer(overlayServerConfig);
+
+                    logger.Information("succesfully setup OBS voting overlay");
                 }
 
                 // Create components
@@ -80,9 +83,14 @@ namespace TwitchChatVotingProxy
                 // Start the chaos mod controller
                 new ChaosModController(chaosPipe, overlayServer, votingReceiver, config);
 
-                while (chaosPipe.IsConnected()) 
+                if (chaosPipe.IsConnected())
                 {
-                    Thread.Sleep(100);
+                    logger.Information("succesfully setup twitch chat voting proxy");
+
+                    while (chaosPipe.IsConnected())
+                    {
+                        Thread.Sleep(100);
+                    }
                 }
             }
             finally

--- a/TwitchChatVotingProxy/TwitchChatVotingProxy.csproj
+++ b/TwitchChatVotingProxy/TwitchChatVotingProxy.csproj
@@ -56,6 +56,7 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>

--- a/twitchVotingOverlay/src/barOverlay.ts
+++ b/twitchVotingOverlay/src/barOverlay.ts
@@ -1,5 +1,5 @@
 import { IChaosOverlayClient } from './chaosOverlayClient/iClient';
-import { IChaosOverlayClientMessage } from './chaosOverlayClient/iMessage';
+import { IChaosOverlayVotingClientMessage } from './chaosOverlayClient/iMessage';
 
 const ANIMATION_DELAY_DELTA = 100;
 const ANIMATION_LENGTH = 600;
@@ -115,7 +115,7 @@ export class BarOverlay {
 	private onEndVote(): void {
 		this.bars.forEach(bar => (bar.isDisabled = true));
 	}
-	private onUpdateVote(message: IChaosOverlayClientMessage): void {
+	private onUpdateVote(message: IChaosOverlayVotingClientMessage): void {
 		const { retainInitialVotes, voteOptions, votingMode } = message;
 		let { totalVotes } = message;
 

--- a/twitchVotingOverlay/src/chaosOverlayClient/iMessage.ts
+++ b/twitchVotingOverlay/src/chaosOverlayClient/iMessage.ts
@@ -1,6 +1,18 @@
 import { IChaosOverlayVoteOption } from './iVoteOption';
 
-export interface IChaosOverlayClientMessage {
+export interface IChaosOverlayBaseClientMessage
+{
+	type : 'SET_VOTES' | 'SET_COLOR';
+	messageData : string;
+}
+
+export interface IChaosOverlayColorClientMessage {
+	colorR : number;
+	colorG : number;
+	colorB : number;
+}
+
+export interface IChaosOverlayVotingClientMessage {
 	retainInitialVotes: boolean;
 	request: 'CREATE' | 'END' | 'NO_VOTING_ROUND' | 'UPDATE';
 	totalVotes: number;

--- a/twitchVotingOverlay/src/chaosOverlayClient/index.ts
+++ b/twitchVotingOverlay/src/chaosOverlayClient/index.ts
@@ -1,5 +1,5 @@
 export { ChaosOverlayClient } from './client';
 export { IChaosOverlayClient } from './iClient';
-export { IChaosOverlayClientMessage } from './iMessage';
+export { IChaosOverlayVotingClientMessage } from './iMessage';
 export { IChaosOverlayVoteOption } from './iVoteOption';
 export { TChaosOverlayClientEvent } from './tEvent';

--- a/twitchVotingOverlay/src/chaosOverlayClient/tEvent.ts
+++ b/twitchVotingOverlay/src/chaosOverlayClient/tEvent.ts
@@ -1,3 +1,3 @@
-import { IChaosOverlayClientMessage } from './iMessage';
+import { IChaosOverlayVotingClientMessage } from './iMessage';
 
-export type TChaosOverlayClientEvent = (event: IChaosOverlayClientMessage) => void;
+export type TChaosOverlayClientEvent = (event: IChaosOverlayVotingClientMessage) => void;

--- a/twitchVotingOverlay/src/style.ts
+++ b/twitchVotingOverlay/src/style.ts
@@ -1,0 +1,11 @@
+/*
+    These are just color utility functions only used by this script
+*/
+function componentToHex(c : number) {
+    var hex = c.toString(16);
+    return hex.length == 1 ? "0" + hex : hex;
+}
+
+export function SetBarProgressColor(r : number, g : number, b : number) {
+    document.body.style.setProperty("--bar-progression", "#" + componentToHex(r) + componentToHex(g) + componentToHex(b));
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/91900600/228976991-4fc1b36f-6e01-45b8-974d-da3a7e2d99c2.png)
![image](https://user-images.githubusercontent.com/91900600/228977023-be05ba85-991d-4f13-ba48-754eac1b9734.png)
<hr/>

![image](https://user-images.githubusercontent.com/91900600/228977062-d9f80204-603c-409e-8a2d-a8ac1e2e138c.png)

- ### `Reset` resets only this option to the default voting overlay bar color.