### PR TITLE
Fixed workshop not loading if it's tab wasn't selected by mouse

### DIFF
--- a/ConfigApp/MainWindow.xaml
+++ b/ConfigApp/MainWindow.xaml
@@ -358,10 +358,7 @@
                     </Grid>
                 </TabItem>
 
-                <TabItem x:Name="workshop_tab" Background="#FFF0F0F0" BorderBrush="LightGray">
-                    <TabItem.Header>
-                        <Label Content="Workshop" MouseLeftButtonDown="workshop_tab_Click" HorizontalAlignment="Stretch"/>
-                    </TabItem.Header>
+                <TabItem x:Name="workshop_tab" Header="Workshop" Background="#FFF0F0F0" BorderBrush="LightGray" Selector.Selected="workshop_tab_Selected">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="25" />

--- a/ConfigApp/MainWindow.xaml.cs
+++ b/ConfigApp/MainWindow.xaml.cs
@@ -692,7 +692,7 @@ namespace ConfigApp
             }
         }
 
-        private async void workshop_tab_Click(object sender, MouseButtonEventArgs e)
+        private async void workshop_tab_Selected(object sender, RoutedEventArgs e)
         {
             // Only fetch them once
             if (m_WorkshopSubmissionItems.Count > 0)


### PR DESCRIPTION
Changed the event that calls the function for loading workshop items from `MouseLeftButtonDown` to `Selector.Selected` so that the workshop items are loaded when the user is navigating with a keyboard.