### PR TITLE
Fix Issue Where MSVC Builds Would Crash

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -358,6 +358,7 @@
     <ClCompile Include="Effects\db\Player\PlayerFlingPlayer.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerJumpJump.cpp" />
     <ClCompile Include="Effects\db\Player\PlayerRandomVehSeat.cpp" />
+    <ClCompile Include="Effects\db\Vehs\VehsBoostBraking.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsPopTiresRandom.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsRotAll.cpp" />
     <ClCompile Include="Effects\db\Vehs\VehsSpamDoors.cpp" />


### PR DESCRIPTION
This was due to the effect "Boost Braking" not being included in the .vcxproj file. This omission caused it to be in a weird state where it was included in the build but not compiled, leading to a mod crash.