### PR TITLE
Add Model Spawn Bypass

### DIFF
--- a/ChaosMod/ChaosMod.vcxproj
+++ b/ChaosMod/ChaosMod.vcxproj
@@ -384,6 +384,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Memory\Hooks\AudioClearnessHook.cpp" />
     <ClCompile Include="Memory\Hooks\ApplyChangeSetEntryHook.cpp" />
+    <ClCompile Include="Memory\Hooks\ModelSpawnBypass.cpp" />
     <ClCompile Include="Memory\Hooks\PresentHook.cpp" />
     <ClCompile Include="Memory\Hooks\ScriptThreadRunHook.cpp" />
     <ClCompile Include="Memory\Hooks\HandleToEntityStructHook.cpp" />

--- a/ChaosMod/Memory/Hooks/ModelSpawnBypass.cpp
+++ b/ChaosMod/Memory/Hooks/ModelSpawnBypass.cpp
@@ -1,0 +1,40 @@
+#include <stdafx.h>
+
+#include "Memory/Hooks/Hook.h"
+
+static DWORD64 ms_ModelSpawnPatchAddr = 0;
+static std::array<BYTE, 24> ms_ModelSpawnPatchOrigBytes;
+
+static bool OnHook()
+{
+	Handle handle = Memory::FindPattern("48 85 C0 0F 84 ? ? ? ? 8B 48 50");
+	if (!handle.IsValid())
+	{
+		LOG("ModelSpawnBypass: Failed to patch model spawn bypass!");
+
+		return false;
+	}
+	else
+	{
+		ms_ModelSpawnPatchAddr = handle.Addr();
+		memcpy_s(ms_ModelSpawnPatchOrigBytes.data(), ms_ModelSpawnPatchOrigBytes.size(),
+		         reinterpret_cast<void *>(ms_ModelSpawnPatchAddr), 24);
+
+		Memory::Write<BYTE>(reinterpret_cast<BYTE *>(ms_ModelSpawnPatchAddr), 0x90, 24);
+
+		LOG("ModelSpawnBypass: Applied model spawn bypass patch!");
+
+		return true;
+	}
+}
+
+static void OnCleanup()
+{
+	if (ms_ModelSpawnPatchAddr)
+	{
+		memcpy_s(reinterpret_cast<void *>(ms_ModelSpawnPatchAddr), 24, ms_ModelSpawnPatchOrigBytes.data(),
+		         ms_ModelSpawnPatchOrigBytes.size());
+	}
+}
+
+static RegisterHook registerHookBypass(OnHook, OnCleanup, "_ModelSpawnBypass");


### PR DESCRIPTION
Allows all models to be spawned such as LOD models. Allows effects such as Reguas' "Inception" to work.

Example:
![20231018160941_1](https://github.com/gta-chaos-mod/ChaosModV/assets/45946092/cc73d2a4-ddba-48ef-8685-184b786445a2)
