### PR TITLE
Increase Wheel types to 12

### DIFF
--- a/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
+++ b/ChaosMod/Effects/db/Misc/MiscVehicleRain.cpp
@@ -31,6 +31,9 @@ static void OnTick()
 
 			// Also apply random upgrades
 			SET_VEHICLE_MOD_KIT(veh, 0);
+
+			SET_VEHICLE_WHEEL_TYPE(veh, g_Random.GetRandomInt(0, 12));
+
 			for (int i = 0; i < 50; i++)
 			{
 				int max = GET_NUM_VEHICLE_MODS(veh, i);

--- a/ChaosMod/Effects/db/Vehs/VehsSpawner.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsSpawner.cpp
@@ -227,7 +227,7 @@ static void OnStartRandom()
 		// Also apply random upgrades
 		SET_VEHICLE_MOD_KIT(veh, 0);
 
-		SET_VEHICLE_WHEEL_TYPE(veh, g_Random.GetRandomInt(0, 7));
+		SET_VEHICLE_WHEEL_TYPE(veh, g_Random.GetRandomInt(0, 12));
 
 		for (int i = 0; i < 50; i++)
 		{

--- a/ChaosMod/Effects/db/Vehs/VehsUpgradeController.cpp
+++ b/ChaosMod/Effects/db/Vehs/VehsUpgradeController.cpp
@@ -52,7 +52,7 @@ static void OnStartRandomUpgrades()
 	{
 		SET_VEHICLE_MOD_KIT(veh, 0);
 
-		SET_VEHICLE_WHEEL_TYPE(veh, g_Random.GetRandomInt(0, 7));
+		SET_VEHICLE_WHEEL_TYPE(veh, g_Random.GetRandomInt(0, 12));
 
 		for (int i = 0; i < 50; i++)
 		{

--- a/ChaosMod/Util/Vehicle.h
+++ b/ChaosMod/Util/Vehicle.h
@@ -170,7 +170,7 @@ inline Vehicle CreateRandomVehicleWithPeds(Vehicle oldHandle, const std::vector<
 	// Also apply random upgrades
 	SET_VEHICLE_MOD_KIT(newVehicle, 0);
 
-	SET_VEHICLE_WHEEL_TYPE(newVehicle, g_Random.GetRandomInt(0, 7));
+	SET_VEHICLE_WHEEL_TYPE(newVehicle, g_Random.GetRandomInt(0, 12));
 
 	for (int i = 0; i < 50; i++)
 	{


### PR DESCRIPTION
and added "random Wheel types" to Vehicle Rain effect as well

------

only tested in 3095. but should be fine with all versions, since GTA will default to Sport(0) if `WheelType` is *invalid* anyway.
*example: trying to apply Track(12) type in pre Tuners update* 


*p.s. and just noticed that my name in `credits.txt` is missing `h`* 😉 