### PR TITLE
future proof(?) shotgun checking logic

### DIFF
--- a/ChaosMod/Util/Weapon.h
+++ b/ChaosMod/Util/Weapon.h
@@ -17,6 +17,8 @@ namespace Util
 		case 984333226:
 		case -275439685:
 		case 317205821:
+		case 1432025498:
+		case 94989220:
 			return true;
 		}
 

--- a/ChaosMod/Util/Weapon.h
+++ b/ChaosMod/Util/Weapon.h
@@ -1,11 +1,21 @@
 #pragma once
 
+#include <unordered_map>
+
 using Hash = unsigned long;
 
 namespace Util
 {
 	inline bool IsWeaponShotgun(Hash weaponHash)
 	{
-		return GET_WEAPONTYPE_GROUP(weaponHash) == "GROUP_SHOTGUN"_hash;
+		static std::unordered_map<Hash, bool> cachedResults;
+		static const Hash shotgunGroup = "GROUP_SHOTGUN"_hash;
+
+		if (const auto result = cachedResults.find(weaponHash); result != cachedResults.end())
+		{
+			return result->second;
+		}
+
+		return cachedResults.emplace(weaponHash, (GET_WEAPONTYPE_GROUP(weaponHash) == shotgunGroup)).first->second;
 	}
 }

--- a/ChaosMod/Util/Weapon.h
+++ b/ChaosMod/Util/Weapon.h
@@ -4,24 +4,8 @@ using Hash = unsigned long;
 
 namespace Util
 {
-	// TODO: Maybe CWeaponInfo has some field which can be checked (instead of hardcoding the weapon hashes)
 	inline bool IsWeaponShotgun(Hash weaponHash)
 	{
-		switch ((long)weaponHash)
-		{
-		case 487013001:
-		case 2017895192:
-		case -1654528753:
-		case -494615257:
-		case -1466123874:
-		case 984333226:
-		case -275439685:
-		case 317205821:
-		case 1432025498:
-		case 94989220:
-			return true;
-		}
-
-		return false;
+		return GET_WEAPONTYPE_GROUP(weaponHash) == "GROUP_SHOTGUN"_hash;
 	}
 }


### PR DESCRIPTION
no more hardcoded weapon hashes ~~*(even this is used by only 2 effects) 😅*~~

from SHV's natives definition, seems old enough to not cause compatibility issues in earlier game versions
`NATIVE_DECL Hash GET_WEAPONTYPE_GROUP(Hash weaponHash) { return invoke<Hash>(0xC3287EE3050FB74C, weaponHash); } // 0xC3287EE3050FB74C 0x5F2DE833 b323`