### PR TITLE
GetGameBuild fix for 34XX

### DIFF
--- a/ChaosMod/Memory/Memory.cpp
+++ b/ChaosMod/Memory/Memory.cpp
@@ -297,11 +297,11 @@ namespace Memory
 	{
 		static auto gameBuild = []() -> std::string
 		{
-			auto handle = Memory::FindPattern("33 DB 38 1D ? ? ? ? 89 5C 24 38");
+			auto handle = Memory::FindPattern("80 3D ? ? ? ? 00 0F 57 C0 48");
 			if (!handle.IsValid())
 				return {};
 
-			std::string buildStr = handle.At(3).Into().Get<char>();
+			std::string buildStr = handle.At(1).Into().At(1).Get<char>();
 			if (buildStr.empty())
 				return {};
 


### PR DESCRIPTION
2944
![image](https://github.com/user-attachments/assets/548687a6-2270-478c-8973-79d9923eb95c)

3411
![image](https://github.com/user-attachments/assets/e194489b-cf9d-4f6d-a151-f18d466a36d9)

due to my very limited knowledge, i'm not sure if it just gone or R* *encrypted* it
has to get it from somewhere else

*tested on 2944, 3411*