### PR TITLE
Fixes for Real First Person

### DIFF
--- a/ChaosMod/Effects/db/Screen/ScreenRealFirstPerson.cpp
+++ b/ChaosMod/Effects/db/Screen/ScreenRealFirstPerson.cpp
@@ -6,23 +6,29 @@
 
 #include "Effects/Register/RegisterEffect.h"
 
-CHAOS_VAR Cam eCamera;
+CHAOS_VAR Cam camera;
 CHAOS_VAR int state = 0;
+CHAOS_VAR Ped lastPlayerPed = 0;
 
 static bool SafetyCheck()
 {
-	Ped playerPed        = PLAYER_PED_ID();
-	Vector3 playerCoords = GET_ENTITY_COORDS(playerPed, true);
-	Vector3 cameraCoords = GET_CAM_COORD(eCamera);
+	Ped playerPed     = PLAYER_PED_ID();
+	Vector3 playerPos = GET_ENTITY_COORDS(playerPed, true);
+	Vector3 cameraPos = DOES_CAM_EXIST(camera)  ? GET_CAM_COORD(camera) : Vector3();
+
+	bool result       = true;
+
 	// Removes camera on player switch, death, and potential non-existence
 	// 02/19/2024 - Added distance check for resets not covered by existing checks
 	if (IS_PLAYER_SWITCH_IN_PROGRESS() || IS_PLAYER_DEAD(PLAYER_ID()) || !ENTITY::DOES_ENTITY_EXIST(playerPed)
 	    || !ENTITY::IS_ENTITY_VISIBLE(playerPed)
-	    || VDIST2(playerCoords.x, playerCoords.y, playerCoords.z, cameraCoords.x, cameraCoords.y, cameraCoords.z) > 3.f)
-	{
-		return true;
-	}
-	return false;
+	    || DOES_CAM_EXIST(camera)
+	           && VDIST2(playerPos.x, playerPos.y, playerPos.z, cameraPos.x, cameraPos.y, cameraPos.z) > 3.f
+	    || lastPlayerPed != playerPed)
+		result = false;
+
+	lastPlayerPed = playerPed;
+	return result;
 }
 
 // OnStart and OnStop code moved to separate functions at Rylxnd's request
@@ -30,10 +36,10 @@ static void RemoveCamera()
 {
 	RENDER_SCRIPT_CAMS(false, false, 0, true, false, 0);
 	CAN_SET_EXIT_STATE_FOR_CAMERA(true);
-	if (DOES_CAM_EXIST(eCamera))
+	if (DOES_CAM_EXIST(camera))
 	{
-		SET_CAM_ACTIVE(eCamera, false);
-		DESTROY_CAM(eCamera, true);
+		SET_CAM_ACTIVE(camera, false);
+		DESTROY_CAM(camera, true);
 	}
 }
 
@@ -41,12 +47,12 @@ static void SetupCamera()
 {
 	Ped playerPed      = PLAYER_PED_ID();
 	Vector3 boneCoords = GET_PED_BONE_COORDS(playerPed, 0x322c, 0, 0, 0);
-	eCamera = CREATE_CAM_WITH_PARAMS("DEFAULT_SCRIPTED_CAMERA", boneCoords.x, boneCoords.y, boneCoords.z, 0, 0, 0, 60,
+	camera = CREATE_CAM_WITH_PARAMS("DEFAULT_SCRIPTED_CAMERA", boneCoords.x, boneCoords.y, boneCoords.z, 0, 0, 0, 60,
 	                                 false, 2);
-	ATTACH_CAM_TO_PED_BONE(eCamera, playerPed, 31086, 0, 0, 0, 0);
+	ATTACH_CAM_TO_PED_BONE(camera, playerPed, 31086, 0, 0, 0, 0);
 
-	SET_CAM_NEAR_CLIP(eCamera, .2f);
-	SET_CAM_AFFECTS_AIMING(eCamera, false);
+	SET_CAM_NEAR_CLIP(camera, .2f);
+	SET_CAM_AFFECTS_AIMING(camera, false);
 }
 
 static void OnStart()
@@ -67,7 +73,7 @@ static void OnTick()
 	{
 	// Normal operation
 	case 0:
-		if (SafetyCheck())
+		if (!SafetyCheck())
 		{
 			RemoveCamera();
 			state = 1;
@@ -75,7 +81,7 @@ static void OnTick()
 		}
 
 		RENDER_SCRIPT_CAMS(true, false, 0, true, false, 0);
-		SET_CAM_ACTIVE(eCamera, true);
+		SET_CAM_ACTIVE(camera, true);
 		CAN_SET_EXIT_STATE_FOR_CAMERA(false);
 		STOP_CUTSCENE_CAM_SHAKING();
 
@@ -83,18 +89,18 @@ static void OnTick()
 		if (IS_PLAYER_FREE_AIMING(PLAYER_ID()))
 		{
 			Vector3 gameCamRot = GET_GAMEPLAY_CAM_ROT(2);
-			SET_CAM_ROT(eCamera, gameCamRot.x, gameCamRot.y, gameCamRot.z, 2);
+			SET_CAM_ROT(camera, gameCamRot.x, gameCamRot.y, gameCamRot.z, 2);
 		}
 		else
 		{
 			Ped playerPed   = PLAYER_PED_ID();
 			Vector3 boneRot = _GET_ENTITY_BONE_ROTATION(playerPed, GET_PED_BONE_INDEX(playerPed, 0x796e));
-			SET_CAM_ROT(eCamera, boneRot.x, boneRot.y + 90, boneRot.z, 2);
+			SET_CAM_ROT(camera, boneRot.x, boneRot.y + 90, boneRot.z, 2);
 		}
 		break;
 	// Recovery
 	case 1:
-		if (!SafetyCheck())
+		if (SafetyCheck())
 		{
 			state = 0;
 			SetupCamera();


### PR DESCRIPTION
Safety check used to check camera coords even if it did not exist or was destroyed. Additionally added a check for player ID change