### PR TITLE
Treewide: .ini configs -> .json configs

### DIFF
--- a/ChaosMod/Components/CrossingChallenge.cpp
+++ b/ChaosMod/Components/CrossingChallenge.cpp
@@ -24,7 +24,7 @@ void CrossingChallenge::SetStartParams()
 	_SET_WEATHER_TYPE_TRANSITION(m_StartWeatherType1, m_StartWeatherType2, m_StartWeatherPercent);
 	SET_CLOCK_TIME(m_ClockHours, m_ClockMinutes, m_ClockSeconds);
 	REMOVE_ALL_PED_WEAPONS(player, false);
-	for (WeaponInfo weapon : m_StartWeapons)
+	for (const auto &weapon : m_StartWeapons)
 		GIVE_WEAPON_TO_PED(player, weapon.hash, weapon.ammo, false, false);
 
 	CLEAR_PLAYER_WANTED_LEVEL(PLAYER_ID());
@@ -196,28 +196,28 @@ static std::string GetWeaponOptionName(Hash weapon)
 
 void CrossingChallenge::SaveConfig()
 {
-	m_ConfigFile.SetValue<bool>("StartEnabled", m_StartEnabled);
-	m_ConfigFile.SetValue<float>("StartLocationX", m_StartLocation.x);
-	m_ConfigFile.SetValue<float>("StartLocationY", m_StartLocation.y);
-	m_ConfigFile.SetValue<float>("StartLocationZ", m_StartLocation.z);
-	m_ConfigFile.SetValue<Hash>("StartVehicle", m_StartVehicleHash);
-	m_ConfigFile.SetValue<float>("StartHeading", m_StartHeading);
-	m_ConfigFile.SetValue<float>("StartCameraHeading", m_StartCameraHeading);
-	m_ConfigFile.SetValue<Hash>("StartWeather1", m_StartWeatherType1);
-	m_ConfigFile.SetValue<Hash>("StartWeather2", m_StartWeatherType2);
-	m_ConfigFile.SetValue<float>("StartWeatherPercent", m_StartWeatherPercent);
-	m_ConfigFile.SetValue<int>("StartHours", m_ClockHours);
-	m_ConfigFile.SetValue<int>("StartMinutes", m_ClockMinutes);
-	m_ConfigFile.SetValue<int>("StartSeconds", m_ClockSeconds);
+	m_ConfigFile.SetValue("StartEnabled", m_StartEnabled);
+	m_ConfigFile.SetValue("StartLocationX", m_StartLocation.x);
+	m_ConfigFile.SetValue("StartLocationY", m_StartLocation.y);
+	m_ConfigFile.SetValue("StartLocationZ", m_StartLocation.z);
+	m_ConfigFile.SetValue("StartVehicle", m_StartVehicleHash);
+	m_ConfigFile.SetValue("StartHeading", m_StartHeading);
+	m_ConfigFile.SetValue("StartCameraHeading", m_StartCameraHeading);
+	m_ConfigFile.SetValue("StartWeather1", m_StartWeatherType1);
+	m_ConfigFile.SetValue("StartWeather2", m_StartWeatherType2);
+	m_ConfigFile.SetValue("StartWeatherPercent", m_StartWeatherPercent);
+	m_ConfigFile.SetValue("StartHours", m_ClockHours);
+	m_ConfigFile.SetValue("StartMinutes", m_ClockMinutes);
+	m_ConfigFile.SetValue("StartSeconds", m_ClockSeconds);
 
-	for (WeaponInfo weapon : m_StartWeapons)
-		m_ConfigFile.SetValue<int>(GetWeaponOptionName(weapon.hash), weapon.ammo);
+	for (const auto &weapon : m_StartWeapons)
+		m_ConfigFile.SetValue(GetWeaponOptionName(weapon.hash), weapon.ammo);
 
-	m_ConfigFile.SetValue<bool>("EndEnabled", m_EndEnabled);
-	m_ConfigFile.SetValue<float>("EndLocationX", m_EndLocation.x);
-	m_ConfigFile.SetValue<float>("EndLocationY", m_EndLocation.y);
-	m_ConfigFile.SetValue<float>("EndLocationZ", m_EndLocation.z);
-	m_ConfigFile.SetValue<float>("EndRadius", m_EndRadius);
+	m_ConfigFile.SetValue("EndEnabled", m_EndEnabled);
+	m_ConfigFile.SetValue("EndLocationX", m_EndLocation.x);
+	m_ConfigFile.SetValue("EndLocationY", m_EndLocation.y);
+	m_ConfigFile.SetValue("EndLocationZ", m_EndLocation.z);
+	m_ConfigFile.SetValue("EndRadius", m_EndRadius);
 
 	m_ConfigFile.WriteFile();
 }
@@ -259,42 +259,42 @@ void CrossingChallenge::CaptureEnd()
 
 CrossingChallenge::CrossingChallenge()
 {
-	m_Enabled = g_OptionsManager.GetConfigValue<bool>({ "EnableCrossingChallenge" }, false);
+	m_Enabled = g_OptionsManager.GetConfigValue({ "EnableCrossingChallenge" }, false);
 
 	if (!m_Enabled)
 		return;
 
-	m_StartEnabled = m_ConfigFile.ReadValue<bool>("StartEnabled", false);
+	m_StartEnabled = m_ConfigFile.ReadValue({ "StartEnabled" }, false);
 	if (m_StartEnabled)
 	{
-		m_StartLocation       = Vector3(m_ConfigFile.ReadValue<float>("StartLocationX", 0.f),
-		                                m_ConfigFile.ReadValue<float>("StartLocationY", 0.f),
-		                                m_ConfigFile.ReadValue<float>("StartLocationZ", 0.f));
-		m_StartVehicleHash    = m_ConfigFile.ReadValue<Hash>("StartVehicle", 0);
-		m_StartHeading        = m_ConfigFile.ReadValue<float>("StartHeading", 0.f);
-		m_StartCameraHeading  = m_ConfigFile.ReadValue<float>("StartCameraHeading", 0.f);
-		m_StartWeatherType1   = m_ConfigFile.ReadValue<Hash>("StartWeather1", 0);
-		m_StartWeatherType2   = m_ConfigFile.ReadValue<Hash>("StartWeather2", 0);
-		m_StartWeatherPercent = m_ConfigFile.ReadValue<float>("StartWeatherPercent", 0.f);
-		m_ClockHours          = m_ConfigFile.ReadValue<int>("StartHours", 0);
-		m_ClockMinutes        = m_ConfigFile.ReadValue<int>("StartMinutes", 0);
-		m_ClockSeconds        = m_ConfigFile.ReadValue<int>("StartSeconds", 0);
+		m_StartLocation       = Vector3(m_ConfigFile.ReadValue({ "StartLocationX" }, 0.f),
+		                                m_ConfigFile.ReadValue({ "StartLocationY" }, 0.f),
+		                                m_ConfigFile.ReadValue({ "StartLocationZ" }, 0.f));
+		m_StartVehicleHash    = m_ConfigFile.ReadValue({ "StartVehicle" }, 0);
+		m_StartHeading        = m_ConfigFile.ReadValue({ "StartHeading" }, 0.f);
+		m_StartCameraHeading  = m_ConfigFile.ReadValue({ "StartCameraHeading" }, 0.f);
+		m_StartWeatherType1   = m_ConfigFile.ReadValue({ "StartWeather1" }, 0);
+		m_StartWeatherType2   = m_ConfigFile.ReadValue({ "StartWeather2" }, 0);
+		m_StartWeatherPercent = m_ConfigFile.ReadValue({ "StartWeatherPercent" }, 0.f);
+		m_ClockHours          = m_ConfigFile.ReadValue({ "StartHours" }, 0);
+		m_ClockMinutes        = m_ConfigFile.ReadValue({ "StartMinutes" }, 0);
+		m_ClockSeconds        = m_ConfigFile.ReadValue({ "StartSeconds" }, 0);
 
 		for (Hash hash : Memory::GetAllWeapons())
 		{
-			int ammo = m_ConfigFile.ReadValue<int>(GetWeaponOptionName(hash), -1);
+			int ammo = m_ConfigFile.ReadValue({ GetWeaponOptionName(hash) }, -1);
 			if (ammo >= 0)
 				m_StartWeapons.emplace_back(WeaponInfo { hash, ammo });
 		}
 	}
 
-	m_EndEnabled = m_ConfigFile.ReadValue<bool>("EndEnabled", false);
+	m_EndEnabled = m_ConfigFile.ReadValue({ "EndEnabled" }, false);
 	if (m_EndEnabled)
 	{
-		m_EndLocation = Vector3(m_ConfigFile.ReadValue<float>("EndLocationX", 0.f),
-		                        m_ConfigFile.ReadValue<float>("EndLocationY", 0.f),
-		                        m_ConfigFile.ReadValue<float>("EndLocationZ", 0.f));
-		m_EndRadius   = m_ConfigFile.ReadValue<float>("EndRadius", 0.f);
+		m_EndLocation =
+		    Vector3(m_ConfigFile.ReadValue({ "EndLocationX" }, 0.f), m_ConfigFile.ReadValue({ "EndLocationY" }, 0.f),
+		            m_ConfigFile.ReadValue({ "EndLocationZ" }, 0.f));
+		m_EndRadius = m_ConfigFile.ReadValue({ "EndRadius" }, 0.f);
 	}
 
 	if (ComponentExists<EffectDispatcher>())

--- a/ChaosMod/Components/CrossingChallenge.h
+++ b/ChaosMod/Components/CrossingChallenge.h
@@ -4,9 +4,9 @@
 
 #include "Component.h"
 #include "Components/EffectDispatcher.h"
+#include "Util/Events.h"
 #include "Util/OptionsFile.h"
 #include "Util/Text.h"
-#include "Util/Events.h"
 
 #define SPLASH_TEXT_DUR_SECS 10
 
@@ -19,7 +19,7 @@ class CrossingChallenge : public Component
 		int ammo;
 	};
 
-	OptionsFile m_ConfigFile { "chaosmod/configs/crossing.ini", { "chaosmod/crossing.ini" } };
+	OptionsFile m_ConfigFile { { "chaosmod/configs/cached/crossingchallenge.json", "chaosmod/crossing.ini" } };
 
 	bool m_Enabled              = false;
 

--- a/ChaosMod/Components/DebugMenu.cpp
+++ b/ChaosMod/Components/DebugMenu.cpp
@@ -4,8 +4,8 @@
 
 #include "Components/EffectDispatcher.h"
 #include "Effects/EnabledEffects.h"
-#include "Util/OptionsManager.h"
 #include "Util/HelpText.h"
+#include "Util/OptionsManager.h"
 
 #define MAX_VIS_ITEMS 15
 

--- a/ChaosMod/Components/EffectDispatchTimer.cpp
+++ b/ChaosMod/Components/EffectDispatchTimer.cpp
@@ -13,8 +13,11 @@ EffectDispatchTimer::EffectDispatchTimer(const std::array<BYTE, 3> &timerColor) 
 	m_DrawTimerBar    = !g_OptionsManager.GetConfigValue({ "DisableTimerBarDraw" }, OPTION_DEFAULT_NO_EFFECT_BAR);
 	m_EffectSpawnTime = g_OptionsManager.GetConfigValue({ "NewEffectSpawnTime" }, OPTION_DEFAULT_EFFECT_SPAWN_TIME);
 
-	m_DistanceChaosState.EnableDistanceBasedEffectDispatch = g_OptionsManager.GetConfigValue(
-	    { "EnableDistanceBasedEffectDispatch" }, OPTION_DEFAULT_DISTANCE_BASED_DISPATCH_ENABLED);
+	m_DistanceChaosState.EnableDistanceBasedEffectDispatch =
+	    g_OptionsManager.GetConfigValue({ "EffectDispatchMode", " EnableDistanceBasedEffectDispatch " },
+	                                    OPTION_DEFAULT_DISTANCE_BASED_DISPATCH_ENABLED)
+	        ? true
+	        : false;
 	m_DistanceChaosState.DistanceToActivateEffect =
 	    g_OptionsManager.GetConfigValue<float>({ "DistanceToActivateEffect" }, OPTION_DEFAULT_EFFECT_SPAWN_DISTANCE);
 	m_DistanceChaosState.DistanceType = static_cast<DistanceChaosState::TravelledDistanceType>(

--- a/ChaosMod/Components/Voting.cpp
+++ b/ChaosMod/Components/Voting.cpp
@@ -20,7 +20,7 @@ Voting::Voting(const std::array<BYTE, 3> &textColor) : Component(), m_TextColor(
 {
 	m_EnableVoting =
 	    g_OptionsManager.GetVotingValue({ "EnableVoting", "EnableTwitchVoting" }, OPTION_DEFAULT_TWITCH_VOTING_ENABLED);
-	m_VoteablePrefix = g_OptionsManager.GetVotingValue<std::string>({ "VoteablePrefix" }, "");
+	m_VoteablePrefix = g_OptionsManager.GetVotingValue<std::string>({ "VoteablePrefix" });
 }
 
 bool Voting::Init()

--- a/ChaosMod/Main.cpp
+++ b/ChaosMod/Main.cpp
@@ -56,7 +56,8 @@ static void ParseEffectsFile()
 {
 	g_EnabledEffects.clear();
 
-	EffectConfig::ReadConfig("chaosmod/configs/effects.ini", g_EnabledEffects, { "chaosmod/effects.ini" });
+	EffectConfig::ReadConfig(
+	    { "chaosmod/configs/effects.json", "chaosmod/configs/effects.ini", "chaosmod/effects.ini" }, g_EnabledEffects);
 }
 
 static void Init()
@@ -139,7 +140,9 @@ static void Init()
 	const auto &effectTimerColor = ParseConfigColorString(
 	    g_OptionsManager.GetConfigValue<std::string>({ "EffectTimedTimerColor" }, OPTION_DEFAULT_TIMED_COLOR));
 
-	g_Random.SetSeed(g_OptionsManager.GetConfigValue({ "Seed" }, 0));
+	auto seed = g_OptionsManager.GetConfigValue<std::string>({ "Seed" });
+	if (!seed.empty())
+		g_Random.SetSeed(std::hash<std::string> {}(seed));
 	g_RandomNoDeterm.SetSeed(GetTickCount64());
 
 	std::set<std::string> blacklistedComponentNames;

--- a/ChaosMod/Util/OptionsManager.h
+++ b/ChaosMod/Util/OptionsManager.h
@@ -9,9 +9,10 @@
 class OptionsManager
 {
   private:
-	OptionsFile m_ConfigFile { "chaosmod/configs/config.ini", { "chaosmod/config.ini" } };
-	OptionsFile m_TwitchFile { "chaosmod/configs/voting.ini",
-		                       { "chaosmod/configs/twitch.ini", "chaosmod/twitch.ini" } };
+	OptionsFile m_ConfigFile { { "chaosmod/configs/config.json", "chaosmod/configs/config.ini",
+		                         "chaosmod/config.ini" } };
+	OptionsFile m_TwitchFile { { "chaosmod/configs/voting.json", "chaosmod/configs/voting.ini",
+		                         "chaosmod/configs/twitch.ini", "chaosmod/twitch.ini" } };
 
   public:
 	void Reset()
@@ -20,29 +21,21 @@ class OptionsManager
 		m_TwitchFile.Reset();
 	}
 
-	template <typename T> inline T GetConfigValue(const std::vector<std::string> &keys, T defaultValue)
+	template <typename T> inline T GetConfigValue(const std::vector<std::string> &lookupKeys, T defaultValue = {})
 	{
-		return GetOptionValue(m_ConfigFile, keys, defaultValue);
+		return GetOptionValue(m_ConfigFile, lookupKeys, defaultValue);
 	}
 
-	template <typename T> inline T GetVotingValue(const std::vector<std::string> &keys, T defaultValue)
+	template <typename T> inline T GetVotingValue(const std::vector<std::string> &lookupKeys, T defaultValue = {})
 	{
-		return GetOptionValue(m_TwitchFile, keys, defaultValue);
+		return GetOptionValue(m_TwitchFile, lookupKeys, defaultValue);
 	}
 
   private:
 	template <typename T>
 	inline T GetOptionValue(const OptionsFile &optionsFile, const std::vector<std::string> &keys, T defaultValue = {})
 	{
-		if constexpr (std::is_same<typename std::remove_const<T>::type, std::string>()
-		              || std::is_same<typename std::remove_const<T>::type, char *>())
-		{
-			return optionsFile.ReadValueString(keys, defaultValue);
-		}
-		else
-		{
-			return optionsFile.ReadValue(keys, defaultValue);
-		}
+		return optionsFile.ReadValue(keys, defaultValue);
 	}
 };
 

--- a/ChaosMod/Util/Random.h
+++ b/ChaosMod/Util/Random.h
@@ -11,8 +11,7 @@ class Random
   public:
 	inline void SetSeed(int seed)
 	{
-		if (seed > 0)
-			m_Random.seed(seed);
+		m_Random.seed(seed);
 	}
 
 	inline int GetRandomInt(int lower, int upper)

--- a/ConfigApp/MainWindow.xaml.cs
+++ b/ConfigApp/MainWindow.xaml.cs
@@ -373,7 +373,7 @@ namespace ConfigApp
                 || OptionsManager.EffectsFile.FoundFilePath == "configs/effects.ini")
             {
                 oldIniFilesExist = true;
-                if (MessageBox.Show("WARNING: Starting with mod version 2.2 config files are automatically migrated to the new JSON format. Clicking OK will migrate to your config files. " +
+                if (MessageBox.Show("WARNING: Starting with mod version 2.2 config files are automatically migrated to the new JSON format. Clicking OK will migrate your config files. " +
                     "This will prevent you from using earlier mod versions with your existing config. Your old config files will be backed up to the configs/old/ directory. Continue?", "ChaosModV", MessageBoxButton.OKCancel, MessageBoxImage.Warning)
                  != MessageBoxResult.OK)
                     return;

--- a/ConfigApp/MainWindow.xaml.cs
+++ b/ConfigApp/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using ConfigApp.Tabs;
 using ConfigApp.Tabs.Settings;
 using ConfigApp.Tabs.Voting;
+using Newtonsoft.Json.Linq;
 using static ConfigApp.Effects;
 
 namespace ConfigApp
@@ -160,25 +161,29 @@ namespace ConfigApp
         private void ParseConfigFile()
         {
             // Meta Effects
-            meta_effects_spawn_dur.Text = OptionsManager.ConfigFile.ReadValue("NewMetaEffectSpawnTime", "600");
-            meta_effects_timed_dur.Text = OptionsManager.ConfigFile.ReadValue("MetaEffectDur", "95");
-            meta_effects_short_timed_dur.Text = OptionsManager.ConfigFile.ReadValue("MetaShortEffectDur", "65");
+            meta_effects_spawn_dur.Text = $"{OptionsManager.ConfigFile.ReadValue("NewMetaEffectSpawnTime", 600)}";
+            meta_effects_timed_dur.Text = $"{OptionsManager.ConfigFile.ReadValue("MetaEffectDur", 95)}";
+            meta_effects_short_timed_dur.Text = $"{OptionsManager.ConfigFile.ReadValue("MetaShortEffectDur", 65)}";
         }
 
         private void WriteConfigFile()
         {
             // Meta Effects
-            OptionsManager.ConfigFile.WriteValue("NewMetaEffectSpawnTime", meta_effects_spawn_dur.Text);
-            OptionsManager.ConfigFile.WriteValue("MetaEffectDur", meta_effects_timed_dur.Text);
-            OptionsManager.ConfigFile.WriteValue("MetaShortEffectDur", meta_effects_short_timed_dur.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("NewMetaEffectSpawnTime", meta_effects_spawn_dur.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("MetaEffectDur", meta_effects_timed_dur.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("MetaShortEffectDur", meta_effects_short_timed_dur.Text);
         }
 
         private void ParseEffectsFile()
         {
+            bool isJson = OptionsManager.EffectsFile.FoundFilePath.EndsWith(".json");
             foreach (string key in OptionsManager.EffectsFile.GetKeys())
             {
-                var value = OptionsManager.EffectsFile.ReadValue(key);
-                var effectData = Utils.ValueStringToEffectData(value);
+                EffectData effectData;
+                if (isJson)
+                    effectData = Utils.ValuesArrayToEffectData(OptionsManager.EffectsFile.ReadValue<JArray>(key));
+                else
+                    effectData = Utils.ValuesArrayToEffectData(OptionsManager.EffectsFile.ReadValue<string>(key));
 
                 m_EffectDataMap?.Add(key, effectData);
             }
@@ -186,18 +191,23 @@ namespace ConfigApp
 
         private void WriteEffectsFile()
         {
-            foreach (var pair in EffectsMap)
+            foreach (var (effectId, _) in EffectsMap)
             {
-                var effectData = GetEffectData(pair.Key);
+                var effectData = GetEffectData(effectId);
 
-                OptionsManager.EffectsFile.WriteValue(pair.Key, $"{(m_TreeMenuItemsMap?[pair.Key].IsChecked is true ? 1 : 0)}"
-                    + $",{(int)effectData.TimedType.GetValueOrDefault(EffectTimedType.NotTimed)}"
-                    + $",{effectData.CustomTime.GetValueOrDefault(0)}"
-                    + $",{effectData.WeightMult.GetValueOrDefault(0)}"
-                    + $",{(effectData.TimedType.GetValueOrDefault(EffectTimedType.NotTimed) == EffectTimedType.Permanent ? 1 : 0)}"
-                    + $",{(effectData.ExcludedFromVoting.GetValueOrDefault(false) ? 1 : 0)}"
-                    + $",\"{(string.IsNullOrEmpty(effectData.CustomName) ? "" : effectData.CustomName)}\""
-                    + $",{effectData.ShortcutKeycode.GetValueOrDefault(0)}");
+                var jsonArray = new JArray
+                {
+                    m_TreeMenuItemsMap?[effectId].IsChecked,
+                    (int)effectData.TimedType.GetValueOrDefault(EffectTimedType.NotTimed),
+                    effectData.CustomTime.GetValueOrDefault(0),
+                    effectData.WeightMult.GetValueOrDefault(0),
+                    effectData.TimedType.GetValueOrDefault(EffectTimedType.NotTimed) == EffectTimedType.Permanent,
+                    effectData.ExcludedFromVoting.GetValueOrDefault(false),
+                    string.IsNullOrEmpty(effectData.CustomName) ? "" : effectData.CustomName,
+                    effectData.ShortcutKeycode.GetValueOrDefault(0)
+                };
+
+                OptionsManager.EffectsFile.WriteValue(effectId, jsonArray);
             }
 
             OptionsManager.EffectsFile.WriteFile();
@@ -347,12 +357,35 @@ namespace ConfigApp
 
         private void OnUserSaveClick(object sender, RoutedEventArgs e)
         {
-            if (OptionsManager.ConfigFile.HasCompatFile("config.ini") || OptionsManager.TwitchFile.HasCompatFile("twitch.ini")
-                || OptionsManager.EffectsFile.HasCompatFile("effects.ini"))
-                if (MessageBox.Show("Note: Config files reside inside the configs/ subdirectory now. Clicking OK will move the files there. " +
+            // Config migration stuff
+            bool oldIniFilesExist = false;
+            if (OptionsManager.ConfigFile.FoundFilePath == "config.ini" || OptionsManager.VotingFile.FoundFilePath == "twitch.ini"
+                || OptionsManager.EffectsFile.FoundFilePath == "effects.ini")
+            {
+                oldIniFilesExist = true;
+                if (MessageBox.Show("Config files reside inside the configs/ subdirectory now. Clicking OK will move the config files there. " +
                     "If you want to play older versions of the mod you will have to move them back. Continue?", "ChaosModV", MessageBoxButton.OKCancel, MessageBoxImage.Warning)
                     != MessageBoxResult.OK)
                     return;
+            }
+
+            if (oldIniFilesExist || OptionsManager.ConfigFile.FoundFilePath == "configs/config.ini" || OptionsManager.VotingFile.FoundFilePath == "configs/twitch.ini" || OptionsManager.VotingFile.FoundFilePath == "configs/voting.ini"
+                || OptionsManager.EffectsFile.FoundFilePath == "configs/effects.ini")
+            {
+                oldIniFilesExist = true;
+                if (MessageBox.Show("WARNING: Starting with mod version 2.2 config files are automatically migrated to the new JSON format. Clicking OK will migrate to your config files. " +
+                    "This will prevent you from using earlier mod versions with your existing config. Your old config files will be backed up to the configs/old/ directory. Continue?", "ChaosModV", MessageBoxButton.OKCancel, MessageBoxImage.Warning)
+                 != MessageBoxResult.OK)
+                    return;
+            }
+
+            if (oldIniFilesExist)
+            {
+                Directory.CreateDirectory("configs/old");
+                File.Move(OptionsManager.ConfigFile.FoundFilePath, $"configs/old/{Path.GetFileName(OptionsManager.ConfigFile.FoundFilePath)}", true);
+                File.Move(OptionsManager.VotingFile.FoundFilePath, $"configs/old/{Path.GetFileName(OptionsManager.VotingFile.FoundFilePath)}", true);
+                File.Move(OptionsManager.EffectsFile.FoundFilePath, $"configs/old/{Path.GetFileName(OptionsManager.EffectsFile.FoundFilePath)}", true);
+            }
 
             WriteConfigFile();
             WriteEffectsFile();
@@ -384,7 +417,7 @@ namespace ConfigApp
                     MessageBoxButton.YesNo, MessageBoxImage.Question);
 
                 if (result == MessageBoxResult.Yes)
-                    OptionsManager.TwitchFile.ResetFile();
+                    OptionsManager.VotingFile.ResetFile();
 
                 Init();
 

--- a/ConfigApp/OptionsManager.cs
+++ b/ConfigApp/OptionsManager.cs
@@ -5,17 +5,17 @@ namespace ConfigApp
 {
     public static class OptionsManager
     {
-        public static OptionsFile ConfigFile { get; } = new OptionsFile("configs/config.ini", "config.ini");
-        public static OptionsFile TwitchFile { get; } = new OptionsFile("configs/voting.ini", "configs/twitch.ini", "twitch.ini");
-        public static OptionsFile EffectsFile { get; } = new OptionsFile("configs/effects.ini", "effects.ini");
+        public static OptionsFile ConfigFile { get; } = new OptionsFile("configs/config.json", "configs/config.ini", "config.ini");
+        public static OptionsFile VotingFile { get; } = new OptionsFile("configs/voting.json", "configs/voting.ini", "configs/twitch.ini", "twitch.ini");
+        public static OptionsFile EffectsFile { get; } = new OptionsFile("configs/effects.json", "configs/effects.ini", "effects.ini");
 
         // These are written to manually
-        public static OptionsFile WorkshopFile { get; } = new OptionsFile("configs/workshop.ini");
+        public static OptionsFile WorkshopFile { get; } = new OptionsFile("configs/workshop.json", "configs/workshop.ini");
 
         public static void ReadFiles()
         {
             ConfigFile.ReadFile();
-            TwitchFile.ReadFile();
+            VotingFile.ReadFile();
             EffectsFile.ReadFile();
             WorkshopFile.ReadFile();
         }
@@ -23,14 +23,13 @@ namespace ConfigApp
         public static void WriteFiles()
         {
             ConfigFile.WriteFile();
-            TwitchFile.WriteFile();
+            VotingFile.WriteFile();
             EffectsFile.WriteFile();
         }
 
         public static void ResetFiles()
         {
             // Exclude TwitchFile as that one is reset separately
-
             ConfigFile.ResetFile();
             EffectsFile.ResetFile();
         }
@@ -43,12 +42,9 @@ namespace ConfigApp
                     File.Delete(file);
             }
 
-            if (ConfigFile.HasCompatFile())
-                deleteFiles(ConfigFile.GetCompatFiles());
-            if (TwitchFile.HasCompatFile())
-                deleteFiles(TwitchFile.GetCompatFiles());
-            if (EffectsFile.HasCompatFile())
-                deleteFiles(EffectsFile.GetCompatFiles());
+            deleteFiles(ConfigFile.CompatFilePaths);
+            deleteFiles(VotingFile.CompatFilePaths);
+            deleteFiles(EffectsFile.CompatFilePaths);
         }
     }
 }

--- a/ConfigApp/Tabs/MetaTab.cs
+++ b/ConfigApp/Tabs/MetaTab.cs
@@ -72,18 +72,18 @@ namespace ConfigApp.Tabs
         public override void OnLoadValues()
         {
             if (m_MetaEffectDispatchTimer is not null)
-                m_MetaEffectDispatchTimer.Text = OptionsManager.ConfigFile.ReadValue("NewMetaEffectSpawnTime", "600");
+                m_MetaEffectDispatchTimer.Text = $"{OptionsManager.ConfigFile.ReadValue("NewMetaEffectSpawnTime", 600)}";
             if (m_MetaEffectDuration is not null)
-                m_MetaEffectDuration.Text = OptionsManager.ConfigFile.ReadValue("MetaEffectDur", "95");
+                m_MetaEffectDuration.Text = $"{OptionsManager.ConfigFile.ReadValue("MetaEffectDur", 95)}";
             if (m_MetaEffectShortDuration is not null)
-                m_MetaEffectShortDuration.Text = OptionsManager.ConfigFile.ReadValue("MetaShortEffectDur", "65");
+                m_MetaEffectShortDuration.Text = $"{OptionsManager.ConfigFile.ReadValue("MetaShortEffectDur", 65)}";
         }
 
         public override void OnSaveValues()
         {
-            OptionsManager.ConfigFile.WriteValue("NewMetaEffectSpawnTime", m_MetaEffectDispatchTimer?.Text);
-            OptionsManager.ConfigFile.WriteValue("MetaEffectDur", m_MetaEffectDuration?.Text);
-            OptionsManager.ConfigFile.WriteValue("MetaShortEffectDur", m_MetaEffectShortDuration?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("NewMetaEffectSpawnTime", m_MetaEffectDispatchTimer?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("MetaEffectDur", m_MetaEffectDuration?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("MetaShortEffectDur", m_MetaEffectShortDuration?.Text);
         }
     }
 }

--- a/ConfigApp/Tabs/Settings/ColorsTab.cs
+++ b/ConfigApp/Tabs/Settings/ColorsTab.cs
@@ -53,11 +53,11 @@ namespace ConfigApp.Tabs.Settings
         public override void OnLoadValues()
         {
             if (OptionsManager.ConfigFile.HasKey("EffectTimerColor") && m_TimerBarColor is not null)
-                m_TimerBarColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue("EffectTimerColor"));
+                m_TimerBarColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue<string>("EffectTimerColor"));
             if (OptionsManager.ConfigFile.HasKey("EffectTextColor") && m_EffectTextColor is not null)
-                m_EffectTextColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue("EffectTextColor"));
+                m_EffectTextColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue<string>("EffectTextColor"));
             if (OptionsManager.ConfigFile.HasKey("EffectTimedTimerColor") && m_EffectTimerBarColor is not null)
-                m_EffectTimerBarColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue("EffectTimedTimerColor"));
+                m_EffectTimerBarColor.SelectedColor = (Color)ColorConverter.ConvertFromString(OptionsManager.ConfigFile.ReadValue<string>("EffectTimedTimerColor"));
         }
 
         public override void OnSaveValues()

--- a/ConfigApp/Tabs/Settings/GeneralTab.cs
+++ b/ConfigApp/Tabs/Settings/GeneralTab.cs
@@ -37,7 +37,11 @@ namespace ConfigApp.Tabs.Settings
             grid.PushRowSpacedPair("Don't draw effect text", m_DisableDrawEffectText = Utils.GenerateCommonCheckBox());
             grid.PopRow();
 
-            grid.PushRowSpacedPair("Random Seed (Leave empty for random seed every time)", m_RandomSeed = Utils.GenerateCommonNumericOnlyTextBox());
+            grid.PushRowSpacedPair("Random Seed (Leave empty for random seed every time)", m_RandomSeed = new TextBox()
+            {
+                Width = 200f,
+                Height = 20f
+            });
             grid.PushRowSpacedPair("Enable effect group weighting", m_EnableEffectGroupWeighting = Utils.GenerateCommonCheckBox());
             grid.PopRow();
 
@@ -53,21 +57,21 @@ namespace ConfigApp.Tabs.Settings
         public override void OnLoadValues()
         {
             if (m_DisableDrawTimer is not null)
-                m_DisableDrawTimer.IsChecked = OptionsManager.ConfigFile.ReadValueBool("DisableTimerBarDraw", false);
+                m_DisableDrawTimer.IsChecked = OptionsManager.ConfigFile.ReadValue("DisableTimerBarDraw", false);
             if (m_DisableDrawEffectText is not null)
-                m_DisableDrawEffectText.IsChecked = OptionsManager.ConfigFile.ReadValueBool("DisableEffectTextDraw", false);
+                m_DisableDrawEffectText.IsChecked = OptionsManager.ConfigFile.ReadValue("DisableEffectTextDraw", false);
             if (m_RandomSeed is not null)
-                m_RandomSeed.Text = OptionsManager.ConfigFile.ReadValue("Seed");
+                m_RandomSeed.Text = OptionsManager.ConfigFile.ReadValue<string>("Seed");
             if (m_MaxRunningEffects is not null)
-                m_MaxRunningEffects.Text = OptionsManager.ConfigFile.ReadValue("MaxParallelRunningEffects", "99");
+                m_MaxRunningEffects.Text = $"{OptionsManager.ConfigFile.ReadValue("MaxParallelRunningEffects", 99)}";
             if (m_EnableEffectGroupWeighting is not null)
-                m_EnableEffectGroupWeighting.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableGroupWeightingAdjustments", true);
+                m_EnableEffectGroupWeighting.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableGroupWeightingAdjustments", true);
             if (m_DisableModOnStartup is not null)
-                m_DisableModOnStartup.IsChecked = OptionsManager.ConfigFile.ReadValueBool("DisableStartup", false);
+                m_DisableModOnStartup.IsChecked = OptionsManager.ConfigFile.ReadValue("DisableStartup", false);
             if (m_EnableFailsafe is not null)
-                m_EnableFailsafe.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableFailsafe", true);
+                m_EnableFailsafe.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableFailsafe", true);
             if (m_EnableModSplashTexts is not null)
-                m_EnableModSplashTexts.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableModSplashTexts", true);
+                m_EnableModSplashTexts.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableModSplashTexts", true);
         }
 
         public override void OnSaveValues()
@@ -75,7 +79,7 @@ namespace ConfigApp.Tabs.Settings
             OptionsManager.ConfigFile.WriteValue("DisableTimerBarDraw", m_DisableDrawTimer?.IsChecked);
             OptionsManager.ConfigFile.WriteValue("DisableEffectTextDraw", m_DisableDrawEffectText?.IsChecked);
             OptionsManager.ConfigFile.WriteValue("Seed", m_RandomSeed?.Text);
-            OptionsManager.ConfigFile.WriteValue("MaxParallelRunningEffects", m_MaxRunningEffects?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("MaxParallelRunningEffects", m_MaxRunningEffects?.Text);
             OptionsManager.ConfigFile.WriteValue("EnableGroupWeightingAdjustments", m_EnableEffectGroupWeighting?.IsChecked);
             OptionsManager.ConfigFile.WriteValue("DisableStartup", m_DisableModOnStartup?.IsChecked);
             OptionsManager.ConfigFile.WriteValue("EnableFailsafe", m_EnableFailsafe?.IsChecked);

--- a/ConfigApp/Tabs/Settings/ModesTab.cs
+++ b/ConfigApp/Tabs/Settings/ModesTab.cs
@@ -121,30 +121,30 @@ namespace ConfigApp.Tabs.Settings
         {
             if (m_DispatchMode is not null)
             {
-                m_DispatchMode.SelectedIndex = !OptionsManager.ConfigFile.ReadValueBool("EnableDistanceBasedEffectDispatch", false) ? 0 : 1;
+                m_DispatchMode.SelectedIndex = !OptionsManager.ConfigFile.ReadValue("EffectDispatchMode", false, "EnableDistanceBasedEffectDispatch") ? 0 : 1;
                 UpdateDispatchModeGridVisibility();
             }
             if (m_EffectDispatchTimer is not null)
-                m_EffectDispatchTimer.Text = OptionsManager.ConfigFile.ReadValue("NewEffectSpawnTime", "30");
+                m_EffectDispatchTimer.Text = $"{OptionsManager.ConfigFile.ReadValue("NewEffectSpawnTime", 30)}";
             if (m_TimedEffectDuration is not null)
-                m_TimedEffectDuration.Text = OptionsManager.ConfigFile.ReadValue("EffectTimedDur", "90");
+                m_TimedEffectDuration.Text = $"{OptionsManager.ConfigFile.ReadValue("EffectTimedDur", 90)}";
             if (m_ShortTimedEffectDuration is not null)
-                m_ShortTimedEffectDuration.Text = OptionsManager.ConfigFile.ReadValue("EffectTimedShortDur", "30");
+                m_ShortTimedEffectDuration.Text = $"{OptionsManager.ConfigFile.ReadValue("EffectTimedShortDur", 30)}";
             if (m_DistanceBasedDispatchDistance is not null)
-                m_DistanceBasedDispatchDistance.Text = OptionsManager.ConfigFile.ReadValue("DistanceToActivateEffect", "250");
+                m_DistanceBasedDispatchDistance.Text = $"{OptionsManager.ConfigFile.ReadValue("DistanceToActivateEffect", 250)}";
             if (m_DistanceBasedDispatchType is not null)
-                m_DistanceBasedDispatchType.SelectedIndex = OptionsManager.ConfigFile.ReadValueInt("DistanceType", 0);
+                m_DistanceBasedDispatchType.SelectedIndex = OptionsManager.ConfigFile.ReadValue("DistanceType", 0);
             if (m_EnableCrossingChallenge is not null)
-                m_EnableCrossingChallenge.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableCrossingChallenge", false);
+                m_EnableCrossingChallenge.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableCrossingChallenge", false);
         }
 
         public override void OnSaveValues()
         {
-            OptionsManager.ConfigFile.WriteValue("NewEffectSpawnTime", m_EffectDispatchTimer?.Text);
-            OptionsManager.ConfigFile.WriteValue("EffectTimedDur", m_TimedEffectDuration?.Text);
-            OptionsManager.ConfigFile.WriteValue("EffectTimedShortDur", m_ShortTimedEffectDuration?.Text);
-            OptionsManager.ConfigFile.WriteValue("EnableDistanceBasedEffectDispatch", m_DispatchMode?.SelectedIndex);
-            OptionsManager.ConfigFile.WriteValue("DistanceToActivateEffect", m_DistanceBasedDispatchDistance?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("NewEffectSpawnTime", m_EffectDispatchTimer?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("EffectTimedDur", m_TimedEffectDuration?.Text);
+            OptionsManager.ConfigFile.WriteValueAsInt("EffectTimedShortDur", m_ShortTimedEffectDuration?.Text);
+            OptionsManager.ConfigFile.WriteValue("EffectDispatchMode", m_DispatchMode?.SelectedIndex);
+            OptionsManager.ConfigFile.WriteValueAsInt("DistanceToActivateEffect", m_DistanceBasedDispatchDistance?.Text);
             OptionsManager.ConfigFile.WriteValue("DistanceType", m_DistanceBasedDispatchType?.SelectedIndex);
             OptionsManager.ConfigFile.WriteValue("EnableCrossingChallenge", m_EnableCrossingChallenge?.IsChecked);
         }

--- a/ConfigApp/Tabs/Settings/ShortcutsTab.cs
+++ b/ConfigApp/Tabs/Settings/ShortcutsTab.cs
@@ -46,15 +46,15 @@ namespace ConfigApp.Tabs.Settings
         public override void OnLoadValues()
         {
             if (m_EnableToggleModShortcut is not null)
-                m_EnableToggleModShortcut.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableToggleModShortcut", true);
+                m_EnableToggleModShortcut.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableToggleModShortcut", true);
             if (m_EnableClearActiveEffectsShortcut is not null)
-                m_EnableClearActiveEffectsShortcut.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableClearEffectsShortcut", true);
+                m_EnableClearActiveEffectsShortcut.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableClearEffectsShortcut", true);
             if (m_EnablePauseTimerShortcut is not null)
-                m_EnablePauseTimerShortcut.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnablePauseTimerShortcut", false);
+                m_EnablePauseTimerShortcut.IsChecked = OptionsManager.ConfigFile.ReadValue("EnablePauseTimerShortcut", false);
             if (m_EnableEffectsMenu is not null)
-                m_EnableEffectsMenu.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableDebugMenu", false);
+                m_EnableEffectsMenu.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableDebugMenu", false);
             if (m_EnableAntiSoftlockShortcut is not null)
-                m_EnableAntiSoftlockShortcut.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EnableAntiSoftlockShortcut", true);
+                m_EnableAntiSoftlockShortcut.IsChecked = OptionsManager.ConfigFile.ReadValue("EnableAntiSoftlockShortcut", true);
         }
 
         public override void OnSaveValues()

--- a/ConfigApp/Tabs/Settings/SoundsTab.cs
+++ b/ConfigApp/Tabs/Settings/SoundsTab.cs
@@ -32,7 +32,7 @@ namespace ConfigApp.Tabs.Settings
         public override void OnLoadValues()
         {
             if (m_UseMCI is not null)
-                m_UseMCI.IsChecked = OptionsManager.ConfigFile.ReadValueBool("EffectSoundUseMCI", false);
+                m_UseMCI.IsChecked = OptionsManager.ConfigFile.ReadValue("EffectSoundUseMCI", false);
         }
 
         public override void OnSaveValues()

--- a/ConfigApp/Tabs/Voting/DiscordTab.cs
+++ b/ConfigApp/Tabs/Voting/DiscordTab.cs
@@ -71,16 +71,8 @@ namespace ConfigApp.Tabs.Voting
             });
             PopRow();
 
-            PushRowSpacedPair("Server ID", m_GuildId = new TextBox()
-            {
-                Width = 125f,
-                Height = 20f
-            });
-            PushRowSpacedPair("Channel ID", m_ChannelId = new TextBox()
-            {
-                Width = 125f,
-                Height = 20f
-            });
+            PushRowSpacedPair("Server ID", m_GuildId = Utils.GenerateCommonNumericOnlyTextBox(default, 125f, 20f));
+            PushRowSpacedPair("Channel ID", m_ChannelId = Utils.GenerateCommonNumericOnlyTextBox(default, 125f, 20f));
 
             SetElementsEnabled(false);
         }
@@ -89,24 +81,24 @@ namespace ConfigApp.Tabs.Voting
         {
             if (m_EnableDiscordVoting is not null)
             {
-                m_EnableDiscordVoting.IsChecked = OptionsManager.TwitchFile.ReadValueBool("EnableVotingDiscord", false);
+                m_EnableDiscordVoting.IsChecked = OptionsManager.VotingFile.ReadValue("EnableVotingDiscord", false);
                 SetElementsEnabled(m_EnableDiscordVoting.IsChecked.GetValueOrDefault());
             }
 
             if (m_Token is not null)
-                m_Token.Password = OptionsManager.TwitchFile.ReadValue("DiscordBotToken");
+                m_Token.Password = OptionsManager.VotingFile.ReadValue<string>("DiscordBotToken");
             if (m_GuildId is not null)
-                m_GuildId.Text = OptionsManager.TwitchFile.ReadValue("DiscordGuildId");
+                m_GuildId.Text = OptionsManager.VotingFile.ReadValue<string>("DiscordGuildId");
             if (m_ChannelId is not null)
-                m_ChannelId.Text = OptionsManager.TwitchFile.ReadValue("DiscordChannelId");
+                m_ChannelId.Text = OptionsManager.VotingFile.ReadValue<string>("DiscordChannelId");
         }
 
         public override void OnSaveValues()
         {
-            OptionsManager.TwitchFile.WriteValue("EnableVotingDiscord", m_EnableDiscordVoting?.IsChecked);
-            OptionsManager.TwitchFile.WriteValue("DiscordBotToken", m_Token?.Password);
-            OptionsManager.TwitchFile.WriteValue("DiscordGuildId", m_GuildId?.Text);
-            OptionsManager.TwitchFile.WriteValue("DiscordChannelId", m_ChannelId?.Text);
+            OptionsManager.VotingFile.WriteValue("EnableVotingDiscord", m_EnableDiscordVoting?.IsChecked);
+            OptionsManager.VotingFile.WriteValue("DiscordBotToken", m_Token?.Password);
+            OptionsManager.VotingFile.WriteValue("DiscordGuildId", m_GuildId?.Text);
+            OptionsManager.VotingFile.WriteValue("DiscordChannelId", m_ChannelId?.Text);
         }
     }
 }

--- a/ConfigApp/Tabs/Voting/GeneralTab.cs
+++ b/ConfigApp/Tabs/Voting/GeneralTab.cs
@@ -132,36 +132,36 @@ namespace ConfigApp.Tabs.Voting
         {
             if (m_EnableVoting is not null)
             {
-                m_EnableVoting.IsChecked = OptionsManager.TwitchFile.ReadValueBool("EnableVoting", false, "EnableTwitchVoting");
+                m_EnableVoting.IsChecked = OptionsManager.VotingFile.ReadValue("EnableVoting", false, "EnableTwitchVoting");
                 SetGridsEnabled(m_EnableVoting.IsChecked.GetValueOrDefault());
             }
             if (m_OverlayMode is not null)
-                m_OverlayMode.SelectedIndex = OptionsManager.TwitchFile.ReadValueInt("VotingOverlayMode", 0, "TwitchVotingOverlayMode");
+                m_OverlayMode.SelectedIndex = OptionsManager.VotingFile.ReadValue("VotingOverlayMode", 0, "TwitchVotingOverlayMode");
             if (m_EnableRandomEffect is not null)
-                m_EnableRandomEffect.IsChecked = OptionsManager.TwitchFile.ReadValueBool("RandomEffectVoteableEnable", true, "TwitchRandomEffectVoteableEnable");
+                m_EnableRandomEffect.IsChecked = OptionsManager.VotingFile.ReadValue("RandomEffectVoteableEnable", true, "TwitchRandomEffectVoteableEnable");
             if (m_SecsBeforeVoting is not null)
-                m_SecsBeforeVoting.Text = OptionsManager.TwitchFile.ReadValue("VotingSecsBeforeVoting", "0", "TwitchVotingSecsBeforeVoting");
+                m_SecsBeforeVoting.Text = $"{OptionsManager.VotingFile.ReadValue("VotingSecsBeforeVoting", 0, "TwitchVotingSecsBeforeVoting")}";
             if (m_PermittedUserNames is not null)
-                m_PermittedUserNames.Text = OptionsManager.TwitchFile.ReadValue("PermittedUsernames", null, "TwitchPermittedUsernames");
+                m_PermittedUserNames.Text = OptionsManager.VotingFile.ReadValue<string>("PermittedUsernames", null, "TwitchPermittedUsernames");
             if (m_VoteablePrefix is not null)
-                m_VoteablePrefix.Text = OptionsManager.TwitchFile.ReadValue("VoteablePrefix", "");
+                m_VoteablePrefix.Text = OptionsManager.VotingFile.ReadValue("VoteablePrefix", "");
             if (m_EnableProportionalVoting is not null)
-                m_EnableProportionalVoting.IsChecked = OptionsManager.TwitchFile.ReadValueBool("VotingChanceSystem", false, "TwitchVotingChanceSystem");
+                m_EnableProportionalVoting.IsChecked = OptionsManager.VotingFile.ReadValue("VotingChanceSystem", false, "TwitchVotingChanceSystem");
             if (m_EnableProportionalVotingRetainInitialChance is not null)
-                m_EnableProportionalVotingRetainInitialChance.IsChecked = OptionsManager.TwitchFile.ReadValueBool("VotingChanceSystemRetainChance", true,
+                m_EnableProportionalVotingRetainInitialChance.IsChecked = OptionsManager.VotingFile.ReadValue("VotingChanceSystemRetainChance", true,
                     "TwitchVotingChanceSystemRetainChance");
         }
 
         public override void OnSaveValues()
         {
-            OptionsManager.TwitchFile.WriteValue("EnableVoting", m_EnableVoting?.IsChecked);
-            OptionsManager.TwitchFile.WriteValue("VotingOverlayMode", m_OverlayMode?.SelectedIndex);
-            OptionsManager.TwitchFile.WriteValue("RandomEffectVoteableEnable", m_EnableRandomEffect?.IsChecked);
-            OptionsManager.TwitchFile.WriteValue("VotingSecsBeforeVoting", m_SecsBeforeVoting?.Text);
-            OptionsManager.TwitchFile.WriteValue("PermittedUsernames", m_PermittedUserNames?.Text);
-            OptionsManager.TwitchFile.WriteValue("VoteablePrefix", m_VoteablePrefix?.Text);
-            OptionsManager.TwitchFile.WriteValue("VotingChanceSystem", m_EnableProportionalVoting?.IsChecked);
-            OptionsManager.TwitchFile.WriteValue("VotingChanceSystemRetainChance", m_EnableProportionalVotingRetainInitialChance?.IsChecked);
+            OptionsManager.VotingFile.WriteValue("EnableVoting", m_EnableVoting?.IsChecked);
+            OptionsManager.VotingFile.WriteValue("VotingOverlayMode", m_OverlayMode?.SelectedIndex);
+            OptionsManager.VotingFile.WriteValue("RandomEffectVoteableEnable", m_EnableRandomEffect?.IsChecked);
+            OptionsManager.VotingFile.WriteValueAsInt("VotingSecsBeforeVoting", m_SecsBeforeVoting?.Text);
+            OptionsManager.VotingFile.WriteValue("PermittedUsernames", m_PermittedUserNames?.Text);
+            OptionsManager.VotingFile.WriteValue("VoteablePrefix", m_VoteablePrefix?.Text);
+            OptionsManager.VotingFile.WriteValue("VotingChanceSystem", m_EnableProportionalVoting?.IsChecked);
+            OptionsManager.VotingFile.WriteValue("VotingChanceSystemRetainChance", m_EnableProportionalVotingRetainInitialChance?.IsChecked);
         }
     }
 }

--- a/ConfigApp/Tabs/Voting/TwitchTab.cs
+++ b/ConfigApp/Tabs/Voting/TwitchTab.cs
@@ -70,23 +70,23 @@ namespace ConfigApp.Tabs.Voting
         {
             if (m_EnableTwitchVoting is not null)
             {
-                m_EnableTwitchVoting.IsChecked = OptionsManager.TwitchFile.ReadValueBool("EnableVotingTwitch", false);
+                m_EnableTwitchVoting.IsChecked = OptionsManager.VotingFile.ReadValue("EnableVotingTwitch", false);
                 SetElementsEnabled(m_EnableTwitchVoting.IsChecked.GetValueOrDefault());
             }
             if (m_ChannelName is not null)
-                m_ChannelName.Text = OptionsManager.TwitchFile.ReadValue("TwitchChannelName");
+                m_ChannelName.Text = OptionsManager.VotingFile.ReadValue<string>("TwitchChannelName");
             if (m_UserName is not null)
-                m_UserName.Text = OptionsManager.TwitchFile.ReadValue("TwitchUserName");
+                m_UserName.Text = OptionsManager.VotingFile.ReadValue<string>("TwitchUserName");
             if (m_Token is not null)
-                m_Token.Password = OptionsManager.TwitchFile.ReadValue("TwitchChannelOAuth");
+                m_Token.Password = OptionsManager.VotingFile.ReadValue<string>("TwitchChannelOAuth");
         }
 
         public override void OnSaveValues()
         {
-            OptionsManager.TwitchFile.WriteValue("EnableVotingTwitch", m_EnableTwitchVoting?.IsChecked);
-            OptionsManager.TwitchFile.WriteValue("TwitchChannelName", m_ChannelName?.Text);
-            OptionsManager.TwitchFile.WriteValue("TwitchUserName", m_UserName?.Text);
-            OptionsManager.TwitchFile.WriteValue("TwitchChannelOAuth", m_Token?.Password);
+            OptionsManager.VotingFile.WriteValue("EnableVotingTwitch", m_EnableTwitchVoting?.IsChecked);
+            OptionsManager.VotingFile.WriteValue("TwitchChannelName", m_ChannelName?.Text);
+            OptionsManager.VotingFile.WriteValue("TwitchUserName", m_UserName?.Text);
+            OptionsManager.VotingFile.WriteValue("TwitchChannelOAuth", m_Token?.Password);
         }
     }
 }

--- a/ConfigApp/Workshop/WorkshopSettingsDialog.xaml.cs
+++ b/ConfigApp/Workshop/WorkshopSettingsDialog.xaml.cs
@@ -15,7 +15,7 @@ namespace ConfigApp
         {
             InitializeComponent();
 
-            workshop_custom_url.Text = OptionsManager.WorkshopFile.ReadValue("WorkshopCustomUrl");
+            workshop_custom_url.Text = OptionsManager.WorkshopFile.ReadValue<string>("WorkshopCustomUrl");
             workshop_custom_url.Watermark = Info.WORKSHOP_DEFAULT_URL;
         }
 

--- a/Shared/OptionsFile.cs
+++ b/Shared/OptionsFile.cs
@@ -1,17 +1,22 @@
 ﻿using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Shared
 {
     public class OptionsFile
     {
-        private readonly string m_FileName;
-        private readonly string[] m_CompatFileNames;
-        private Dictionary<string, string?> m_Options = new();
+        public string FoundFilePath { get; private set; } = string.Empty;
+        public string[] CompatFilePaths { get; private set; }
 
-        public OptionsFile(string fileName, params string[] compatFileNames)
+        private readonly string m_FilePath;
+        private bool m_IsJson = false;
+        private Dictionary<string, JToken?> m_Options = new();
+
+        public OptionsFile(string filePath, params string[] compatFilePaths)
         {
-            m_FileName = fileName;
-            m_CompatFileNames = compatFileNames;
+            m_FilePath = filePath;
+            CompatFilePaths = compatFilePaths;
         }
 
         public bool HasKey(params string[] keys)
@@ -31,7 +36,7 @@ namespace Shared
                 yield return option.Key;
         }
 
-        public string? ReadValue(string key, string? defaultValue = null, params string[] compatKeys)
+        public T? ReadValue<T>(string key, T? defaultValue = default, params string[] compatKeys)
         {
             var keys = compatKeys.Prepend(key);
             foreach (var _key in keys)
@@ -39,56 +44,37 @@ namespace Shared
                 if (!m_Options.ContainsKey(_key) || m_Options[_key] is null)
                     continue;
 
-                return m_Options[_key];
+                if (typeof(T) == typeof(bool) && !m_IsJson)
+                {
+                    string? str = ReadValue<string>(_key, $"{((bool?)Convert.ChangeType(defaultValue, typeof(bool)) == true ? "1" : "0")}");
+                    if (str is null)
+                        return defaultValue;
+
+                    if (int.TryParse(str, out int result))
+                        return (T?)Convert.ChangeType(result != 0, typeof(T));
+                }
+
+                return m_Options[_key].ToObject<T>();
             }
 
             return defaultValue;
         }
 
-        public int ReadValueInt(string key, int defaultValue, params string[] compatKeys)
+        public void WriteValue<T>(string key, T? value)
         {
-            if (!int.TryParse(ReadValue(key, null, compatKeys), out int result))
-                result = defaultValue;
-
-            return result;
+            if (value is null || (value is string && string.IsNullOrEmpty(value as string)))
+                m_Options[key] = null;
+            else if (value is JObject o)
+                m_Options[key] = o;
+            else if (value is JArray a)
+                m_Options[key] = a;
+            else
+                m_Options[key] = new JValue(value);
         }
 
-        public long ReadValueLong(string key, long defaultValue, params string[] compatKeys)
+        public void WriteValueAsInt(string key, string? value)
         {
-            if (!long.TryParse(ReadValue(key, null, compatKeys), out long result))
-                result = defaultValue;
-
-            return result;
-        }
-
-        public bool ReadValueBool(string key, bool defaultValue, params string[] compatKeys)
-        {
-            var keys = compatKeys.Prepend(key);
-            foreach (var _key in keys)
-            {
-                if (!m_Options.ContainsKey(_key) || m_Options[_key] == null)
-                    continue;
-
-                if (int.TryParse(ReadValue(_key), out int result))
-                    return result != 0;
-            }
-
-            return defaultValue;
-        }
-
-        public void WriteValue(string key, string? value)
-        {
-            m_Options[key] = value is null || string.IsNullOrEmpty(value) ? null : value;
-        }
-
-        public void WriteValue(string key, int? value)
-        {
-            WriteValue(key, $"{value}");
-        }
-
-        public void WriteValue(string key, bool? value)
-        {
-            WriteValue(key, value is true ? 1 : 0);
+            m_Options[key] = value is null || string.IsNullOrEmpty(value) ? null : new JValue(int.Parse(value));
         }
 
         public void ReadFile()
@@ -106,14 +92,17 @@ namespace Shared
             }
 
             string? data;
-            if ((data = readData(m_FileName)) == null)
+            if ((data = readData(m_FilePath)) != null)
+                FoundFilePath = m_FilePath;
+            else
             {
                 bool dataRead = false;
-                foreach (var compatFileName in m_CompatFileNames)
+                foreach (var compatFileName in CompatFilePaths)
                 {
                     if ((data = readData(compatFileName)) != null)
                     {
                         dataRead = true;
+                        FoundFilePath = compatFileName;
                         break;
                     }
                 }
@@ -124,46 +113,62 @@ namespace Shared
 
             m_Options.Clear();
 
-            if (data is not null)
+            if (data is not null && FoundFilePath is not null)
             {
-                foreach (string line in data.Split('\n'))
+                if (FoundFilePath.EndsWith(".json"))
                 {
-                    if (!line.Contains('='))
-                        continue;
+                    m_IsJson = true;
 
-                    var keyValuePair = line.Split('=', 2, System.StringSplitOptions.RemoveEmptyEntries
-                        | System.StringSplitOptions.TrimEntries);
+                    var json = JObject.Parse(data);
+                    foreach (var (key, value) in json)
+                        m_Options[key] = value;
+                }
+                else if (FoundFilePath.EndsWith(".ini"))
+                {
+                    m_IsJson = false;
 
-                    m_Options[keyValuePair[0]] = keyValuePair.Length == 2 ? keyValuePair[1] : null;
+                    foreach (string line in data.Split('\n'))
+                    {
+                        if (!line.Contains('='))
+                            continue;
+
+                        var keyValuePair = line.Split('=', 2, System.StringSplitOptions.RemoveEmptyEntries
+                            | System.StringSplitOptions.TrimEntries);
+
+                        m_Options[keyValuePair[0]] = keyValuePair.Length == 2 ? new JValue(keyValuePair[1]) : null;
+                    }
                 }
             }
         }
 
         public void WriteFile()
         {
-            if (m_FileName is null)
+            if (m_FilePath is null)
                 return;
 
-            string data = string.Empty;
+            FoundFilePath = m_FilePath;
 
-            foreach (var option in m_Options)
-                data += $"{option.Key}={option.Value}\n";
+            var json = new JObject();
+            foreach (var (key, value) in m_Options)
+                json[key] = value;
 
-            var directory = Path.GetDirectoryName(m_FileName);
+            var directory = Path.GetDirectoryName(m_FilePath);
             if (directory is not null)
                 Directory.CreateDirectory(directory);
-            File.WriteAllText(m_FileName, data);
+
+            File.WriteAllText(m_FilePath, JsonConvert.SerializeObject(json));
         }
 
         public void ResetFile()
         {
-            if (m_FileName is null)
+            if (m_FilePath is null)
                 return;
 
-            var directory = Path.GetDirectoryName(m_FileName);
+            var directory = Path.GetDirectoryName(m_FilePath);
             if (directory is not null)
                 Directory.CreateDirectory(directory);
-            File.WriteAllText(m_FileName, null);
+
+            File.WriteAllText(m_FilePath, null);
 
             // Reset all options too
             m_Options = new();
@@ -171,23 +176,13 @@ namespace Shared
 
         public bool HasCompatFile()
         {
-            foreach (var compatFileName in m_CompatFileNames)
+            foreach (var compatFileName in CompatFilePaths)
             {
                 if (File.Exists(compatFileName))
                     return true;
             }
 
             return false;
-        }
-
-        public bool HasCompatFile(string fileName)
-        {
-            return m_CompatFileNames.Contains(fileName) && File.Exists(fileName);
-        }
-
-        public string[] GetCompatFiles()
-        {
-            return m_CompatFileNames;
         }
     }
 }

--- a/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
+++ b/TwitchChatVotingProxy/TwitchChatVotingProxy.cs
@@ -32,22 +32,22 @@ namespace TwitchChatVotingProxy
             m_Logger.Information("Starting chaos mod twitch proxy");
             m_Logger.Information("===============================");
 
-            var config = new OptionsFile("chaosmod/configs/voting.ini", "chaosmod/configs/twitch.ini", "chaosmod/twitch.ini");
+            var config = new OptionsFile("chaosmod/configs/voting.json", "chaosmod/configs/voting.ini", "chaosmod/configs/twitch.ini", "chaosmod/twitch.ini");
             config.ReadFile();
 
             var mutex = new Mutex(false, "ChaosModVVotingMutex");
             mutex.WaitOne();
 
-            var votingMode = (EVotingMode)config.ReadValueInt("VotingChanceSystem", 0, "TwitchVotingChanceSystem");
-            var overlayMode = (EOverlayMode)config.ReadValueInt("VotingOverlayMode", 0, "TwitchVotingOverlayMode");
-            var retainInitialVotes = config.ReadValueBool("VotingChanceSystemRetainChance", false, "TwitchVotingChanceSystemRetainChance");
+            var votingMode = (EVotingMode)config.ReadValue("VotingChanceSystem", 0, "TwitchVotingChanceSystem");
+            var overlayMode = (EOverlayMode)config.ReadValue("VotingOverlayMode", 0, "TwitchVotingOverlayMode");
+            var retainInitialVotes = config.ReadValue("VotingChanceSystemRetainChance", false, "TwitchVotingChanceSystemRetainChance");
 
             // Check if OBS overlay should be shown
             OverlayServer.OverlayServer? overlayServer = null;
             if (overlayMode == EOverlayMode.OVERLAY_OBS)
             {
                 // Create component
-                var overlayServerPort = config.ReadValueInt("OverlayServerPort", 9091);
+                var overlayServerPort = config.ReadValue("OverlayServerPort", 9091);
                 var overlayServerConfig = new OverlayServerConfig(votingMode, retainInitialVotes, overlayServerPort);
                 overlayServer = new OverlayServer.OverlayServer(overlayServerConfig);
             }
@@ -56,9 +56,9 @@ namespace TwitchChatVotingProxy
             var chaosPipe = new ChaosPipeClient();
 
             var votingReceivers = new List<(string Name, IVotingReceiver VotingReceiver)>();
-            if (config.ReadValueBool("EnableVotingTwitch", false))
+            if (config.ReadValue("EnableVotingTwitch", false))
                 votingReceivers.Add(("Twitch", new TwitchVotingReceiver(config, chaosPipe)));
-            if (config.ReadValueBool("EnableVotingDiscord", false))
+            if (config.ReadValue("EnableVotingDiscord", false))
                 votingReceivers.Add(("Discord", new DiscordVotingReceiver(config, chaosPipe)));
 
             foreach (var votingReceiver in votingReceivers)

--- a/TwitchChatVotingProxy/VotingReceiver/DiscordVotingReceiver.cs
+++ b/TwitchChatVotingProxy/VotingReceiver/DiscordVotingReceiver.cs
@@ -26,9 +26,9 @@ namespace TwitchChatVotingProxy.VotingReceiver
 
         public DiscordVotingReceiver(OptionsFile config, ChaosPipeClient chaosPipe)
         {
-            m_BotToken = config.ReadValue("DiscordBotToken");
-            m_GuildId = (ulong)config.ReadValueLong("DiscordGuildId", 0);
-            m_ChannelId = (ulong)config.ReadValueLong("DiscordChannelId", 0);
+            m_BotToken = config.ReadValue<string>("DiscordBotToken");
+            m_GuildId = config.ReadValue<ulong>("DiscordGuildId", 0);
+            m_ChannelId = config.ReadValue<ulong>("DiscordChannelId", 0);
 
             m_ChaosPipe = chaosPipe;
         }

--- a/TwitchChatVotingProxy/VotingReceiver/TwitchVotingReceiver.cs
+++ b/TwitchChatVotingProxy/VotingReceiver/TwitchVotingReceiver.cs
@@ -30,9 +30,9 @@ namespace TwitchChatVotingProxy.VotingReceiver
 
         public TwitchVotingReceiver(OptionsFile config, ChaosPipeClient chaosPipe)
         {
-            m_ChannelName = config.ReadValue("TwitchChannelName");
-            m_OAuth = config.ReadValue("TwitchChannelOAuth");
-            m_UserName = config.ReadValue("TwitchUserName");
+            m_ChannelName = config.ReadValue<string>("TwitchChannelName");
+            m_OAuth = config.ReadValue<string>("TwitchChannelOAuth");
+            m_UserName = config.ReadValue<string>("TwitchUserName");
 
             m_ChaosPipe = chaosPipe;
         }


### PR DESCRIPTION
Successor to #2717.

Converts all config files to new JSON format on write while keeping compatibility with old .ini config files on read. Values are written as their actual type instead of stringifying everything. Also includes a bunch of (mostly) related cleanups and new logs plastered around in config related code.